### PR TITLE
Enhance auth with refresh tokens, implement Telecom & TV Subscription services (CRUD operations), add routes/handlers, and simplify DataConn setup

### DIFF
--- a/db/models/telcom_product.go
+++ b/db/models/telcom_product.go
@@ -16,7 +16,7 @@ type Plan struct {
 }
 
 type PlanUpdate struct {
-	Amount   *float64 `json:"amount,omitempty"`
-	Validity *string  `json:"validity,omitempty"`
-	Size     *string  `json:"size,omitempty"`
+	Amount   float64 `json:"amount,omitempty"`
+	Validity string  `json:"validity,omitempty"`
+	Size     string  `json:"size,omitempty"`
 }

--- a/db/models/tv_subs.go
+++ b/db/models/tv_subs.go
@@ -1,0 +1,14 @@
+package models
+
+type TVSub struct {
+	ID          int     `db:"plan_id"`
+	Package     string  `db:"package"`
+	PackageName string  `db:"package_name"`
+	Amount      float64 `db:"amount"`
+}
+
+type TVSubUpdate struct {
+	Package     *string
+	PackageName *string
+	Amount      *float64
+}

--- a/db/mongo/banks.go
+++ b/db/mongo/banks.go
@@ -342,6 +342,9 @@ func (m *mongoStore) GetBalanceDetails(id string) (models.Balance, error) {
 	var resp models.Balance
 	err := result.Decode(&resp)
 	if err != nil {
+		if err == mongo.ErrNoDocuments {
+			return models.Balance{}, nil
+		}
 		return models.Balance{}, err
 	}
 

--- a/db/sqlstore/store.go
+++ b/db/sqlstore/store.go
@@ -95,17 +95,17 @@ func (s *SqlStore) UpdatePlan(planID int, updatedPlan models.PlanUpdate) error {
 	setClauses := []string{}
 	args := []interface{}{}
 
-	if updatedPlan.Amount != nil {
+	if updatedPlan.Amount != 0 {
 		setClauses = append(setClauses, "amount = ?")
-		args = append(args, *updatedPlan.Amount)
+		args = append(args, updatedPlan.Amount)
 	}
-	if updatedPlan.Validity != nil {
+	if updatedPlan.Validity != "" {
 		setClauses = append(setClauses, "validity = ?")
-		args = append(args, *updatedPlan.Validity)
+		args = append(args, updatedPlan.Validity)
 	}
-	if updatedPlan.Size != nil {
+	if updatedPlan.Size != "" {
 		setClauses = append(setClauses, "size = ?")
-		args = append(args, *updatedPlan.Size)
+		args = append(args, updatedPlan.Size)
 	}
 
 	if len(setClauses) == 0 {

--- a/db/sqlstore/tv_sub.go
+++ b/db/sqlstore/tv_sub.go
@@ -1,0 +1,194 @@
+package sqlstore
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/aremxyplug-be/db/models"
+	"go.uber.org/zap"
+)
+
+var validTableName = regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9_]{0,63}$`)
+
+func validateTableName(table string) error {
+	if !validTableName.MatchString(table) {
+		return errors.New("invalid table name format")
+	}
+	return nil
+}
+
+// GetPlans retrieves all plans from specified table
+func (s *SqlStore) GetTVSubs(table string) ([]models.TVSub, error) {
+	ctx := context.Background()
+
+	if err := validateTableName(table); err != nil {
+		return nil, fmt.Errorf("invalid table name: %w", err)
+	}
+
+	query := fmt.Sprintf(
+		"SELECT plan_id, package, package_name, amount FROM %s",
+		sanitizeTableName(table),
+	)
+
+	rows, err := s.db.QueryContext(ctx, query)
+	if err != nil {
+		s.logger.Error("Error querying plans", zap.String("table", table), zap.Error(err))
+		return nil, fmt.Errorf("failed to query %s plans: %w", table, err)
+	}
+	defer rows.Close()
+
+	var plans []models.TVSub
+	for rows.Next() {
+		var p models.TVSub
+		if err := rows.Scan(
+			&p.ID,
+			&p.Package,
+			&p.PackageName,
+			&p.Amount,
+		); err != nil {
+			s.logger.Error("Error scanning plan row", zap.String("table", table), zap.Error(err))
+			return nil, fmt.Errorf("failed to scan %s plan: %w", table, err)
+		}
+		plans = append(plans, p)
+	}
+
+	if err := rows.Err(); err != nil {
+		s.logger.Error("Error iterating plan rows", zap.String("table", table), zap.Error(err))
+		return nil, fmt.Errorf("row iteration error for %s: %w", table, err)
+	}
+
+	s.logger.Info("Plans retrieved", zap.String("table", table), zap.Int("count", len(plans)))
+	return plans, nil
+}
+
+// CreatePlan inserts a new plan into specified table
+func (s *SqlStore) CreateTvSub(table string, plan models.TVSub) (int, error) {
+	ctx := context.Background()
+
+	if err := validateTableName(table); err != nil {
+		return 0, fmt.Errorf("invalid table name: %w", err)
+	}
+
+	query := fmt.Sprintf(
+		`INSERT INTO %s (package, package_name, amount)
+		VALUES (?, ?, ?)`,
+		sanitizeTableName(table),
+	)
+
+	result, err := s.db.ExecContext(ctx, query,
+		plan.Package,
+		plan.PackageName,
+		plan.Amount,
+	)
+	if err != nil {
+		s.logger.Error("Failed to insert plan", zap.String("table", table), zap.Error(err))
+		return 0, fmt.Errorf("insert into %s failed: %w", table, err)
+	}
+
+	id, err := result.LastInsertId()
+	if err != nil {
+		s.logger.Error("Failed to get last insert ID", zap.String("table", table), zap.Error(err))
+		return 0, fmt.Errorf("failed to get insert ID from %s: %w", table, err)
+	}
+
+	s.logger.Info("Plan created", zap.String("table", table), zap.Int64("planID", id))
+	return int(id), nil
+}
+
+// UpdatePlan modifies fields of an existing plan in specified table
+func (s *SqlStore) UpdateTvSub(table string, planID int, upd models.TVSubUpdate) error {
+	ctx := context.Background()
+
+	if err := validateTableName(table); err != nil {
+		return fmt.Errorf("invalid table name: %w", err)
+	}
+
+	setClauses := []string{}
+	args := []interface{}{}
+
+	if upd.Package != nil {
+		setClauses = append(setClauses, "package = ?")
+		args = append(args, *upd.Package)
+	}
+	if upd.PackageName != nil {
+		setClauses = append(setClauses, "package_name = ?")
+		args = append(args, *upd.PackageName)
+	}
+	if upd.Amount != nil {
+		setClauses = append(setClauses, "amount = ?")
+		args = append(args, *upd.Amount)
+	}
+
+	if len(setClauses) == 0 {
+		return fmt.Errorf("no fields provided for update")
+	}
+
+	args = append(args, planID)
+	query := fmt.Sprintf(
+		"UPDATE %s SET %s WHERE plan_id = ?",
+		sanitizeTableName(table),
+		strings.Join(setClauses, ", "),
+	)
+
+	result, err := s.db.ExecContext(ctx, query, args...)
+	if err != nil {
+		s.logger.Error("Failed to update plan", zap.String("table", table), zap.Error(err))
+		return fmt.Errorf("update failed for %s: %w", table, err)
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		s.logger.Error("Failed to check affected rows", zap.String("table", table), zap.Error(err))
+		return fmt.Errorf("rows affected check failed for %s: %w", table, err)
+	}
+
+	if rowsAffected == 0 {
+		s.logger.Warn("Plan does not exist", zap.String("table", table), zap.Int("planID", planID))
+		return fmt.Errorf("%s plan ID %d does not exist", table, planID)
+	}
+
+	s.logger.Info("Plan updated", zap.String("table", table), zap.Int("planID", planID))
+	return nil
+}
+
+// DeletePlan removes a plan by ID from specified table
+func (s *SqlStore) DeleteTvSub(table string, planID int) error {
+	ctx := context.Background()
+
+	if err := validateTableName(table); err != nil {
+		return fmt.Errorf("invalid table name: %w", err)
+	}
+
+	query := fmt.Sprintf(
+		"DELETE FROM %s WHERE plan_id = ?",
+		sanitizeTableName(table),
+	)
+
+	result, err := s.db.ExecContext(ctx, query, planID)
+	if err != nil {
+		s.logger.Error("Failed to delete plan", zap.String("table", table), zap.Error(err))
+		return fmt.Errorf("delete failed for %s: %w", table, err)
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		s.logger.Error("Failed to check affected rows", zap.String("table", table), zap.Error(err))
+		return fmt.Errorf("rows affected check failed for %s: %w", table, err)
+	}
+
+	if rowsAffected == 0 {
+		s.logger.Warn("Plan does not exist", zap.String("table", table), zap.Int("planID", planID))
+		return fmt.Errorf("%s plan ID %d does not exist", table, planID)
+	}
+
+	s.logger.Info("Plan deleted", zap.String("table", table), zap.Int("planID", planID))
+	return nil
+}
+
+// sanitizeTableName provides additional safety layer (quotes table name)
+func sanitizeTableName(table string) string {
+	return fmt.Sprintf("`%s`", strings.ReplaceAll(table, "`", ""))
+}

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aremxyplug-be/config"
 	"github.com/aremxyplug-be/lib/key_generator"
 	tokengenerator "github.com/aremxyplug-be/lib/tokekngenerator"
+	"github.com/aremxyplug-be/types/dto"
 )
 
 type AuthConn struct {
@@ -19,7 +20,7 @@ func NewAuthConn(secret *config.Secrets) *AuthConn {
 		log.Println(err)
 	}
 
-	privateKey, err := key_generator.GeneratePrivateKey(secret.JWTPublicKey)
+	privateKey, err := key_generator.GeneratePrivateKey(secret.JWTPrivateKey)
 	if err != nil {
 		// do something with the error
 		log.Println(err)
@@ -35,16 +36,60 @@ func NewAuthConn(secret *config.Secrets) *AuthConn {
 // authorisation middleware
 func (a *AuthConn) Authorize(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		//get the token from the header
+		// Get the token from the header
 		token := r.Header.Get("Authorization")
-		//validate the token
+		// Validate the token
 		_, err := a.jwt.ValidateToken(token)
 		if err != nil {
-			w.WriteHeader(http.StatusUnauthorized)
-			w.Write([]byte("Unauthorized: invalid or missing token: " + err.Error()))
-			return
+			// Check for the refresh_token in cookies
+			cookie, err := r.Cookie("refresh_token")
+			if err != nil {
+				w.WriteHeader(http.StatusUnauthorized)
+				w.Write([]byte("Unauthorized: invalid or missing token and refresh token: " + err.Error()))
+				return
+			}
+
+			// Validate the refresh token
+			claims, err := a.jwt.ValidateToken(cookie.Value)
+			if err != nil {
+				w.WriteHeader(http.StatusUnauthorized)
+				w.Write([]byte("Unauthorized: invalid refresh token: " + err.Error()))
+				return
+			}
+
+			newClaims := dto.Claims{
+				PersonId: claims.ID,
+			}
+
+			// Generate a new auth token
+			newAuthToken, err := a.jwt.GenerateToken(newClaims)
+			if err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				w.Write([]byte("Error generating new auth token: " + err.Error()))
+				return
+			}
+
+			newRefreshToken, err := a.jwt.GenerateTokenWithExpiration(newClaims, tokengenerator.RefreshTokenDuration)
+			if err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				w.Write([]byte("Error generating new token: " + err.Error()))
+				return
+			}
+
+			http.SetCookie(w, &http.Cookie{
+				Name:     "refresh_token",
+				Value:    newRefreshToken,
+				MaxAge:   1800,
+				HttpOnly: true,
+				Secure:   false,
+				Path:     "/",
+				SameSite: http.SameSiteNoneMode,
+			})
+
+			// Set the new auth token in the response header
+			w.Header().Set("x-new-auth-header", newAuthToken)
 		}
+
 		next.ServeHTTP(w, r)
 	})
-
 }

--- a/lib/services/product.go
+++ b/lib/services/product.go
@@ -1,0 +1,16 @@
+package services
+
+import (
+	telecom "github.com/aremxyplug-be/lib/services/telcom"
+	"github.com/aremxyplug-be/lib/services/tvsub"
+)
+
+type ProductServiceImpl struct {
+	tvsub.TVSubService
+	telecom.TelecomProducts
+}
+
+type ProductService interface {
+	tvsub.TVSubService
+	telecom.TelecomProducts
+}

--- a/lib/services/telcom/telecom_service.go
+++ b/lib/services/telcom/telecom_service.go
@@ -1,0 +1,82 @@
+package telecom
+
+import (
+	"github.com/aremxyplug-be/db/models"
+	"github.com/aremxyplug-be/db/sqlstore"
+	"go.uber.org/zap"
+)
+
+type TelecomProducts interface {
+	GetProducts(id int) ([]models.Product, error)
+	CreatePlan(plan models.Plan) (int, error)
+	UpdatePlan(id int, data models.PlanUpdate) error
+	DeletePlan(id int) error
+	GetPlans(id int) ([]models.Plan, error)
+}
+
+type TelecomServiceImpl struct {
+	logger *zap.Logger
+	store  *sqlstore.SqlStore
+}
+
+func NewTelecomService(store *sqlstore.SqlStore, logger *zap.Logger) TelecomProducts {
+	return &TelecomServiceImpl{
+		logger: logger,
+		store:  store,
+	}
+}
+
+func (s *TelecomServiceImpl) GetProducts(id int) ([]models.Product, error) {
+	s.logger.Info("Fetching products")
+	products, err := s.store.GetProducts(id)
+	if err != nil {
+		s.logger.Error("Error fetching products", zap.Error(err))
+		return nil, err
+	}
+	s.logger.Info("Fetched products successfully", zap.Int("count", len(products)))
+	return products, nil
+}
+
+func (s *TelecomServiceImpl) CreatePlan(plan models.Plan) (int, error) {
+	s.logger.Info("Creating plan")
+	id, err := s.store.CreatePlan(plan)
+	if err != nil {
+		s.logger.Error("Error creating plan", zap.Error(err))
+		return 0, err
+	}
+	s.logger.Info("Created plan successfully", zap.Int("id", id))
+	return id, nil
+}
+
+func (s *TelecomServiceImpl) UpdatePlan(id int, data models.PlanUpdate) error {
+	s.logger.Info("Updating plan", zap.Int("id", id))
+	err := s.store.UpdatePlan(id, data)
+	if err != nil {
+		s.logger.Error("Error updating plan", zap.Error(err))
+		return err
+	}
+	s.logger.Info("Updated plan successfully", zap.Int("id", id))
+	return nil
+}
+
+func (s *TelecomServiceImpl) DeletePlan(id int) error {
+	s.logger.Info("Deleting plan", zap.Int("id", id))
+	err := s.store.DeletePlan(id)
+	if err != nil {
+		s.logger.Error("Error deleting plan", zap.Error(err))
+		return err
+	}
+	s.logger.Info("Deleted plan successfully", zap.Int("id", id))
+	return nil
+}
+
+func (s *TelecomServiceImpl) GetPlans(id int) ([]models.Plan, error) {
+	s.logger.Info("Fetching plans")
+	plans, err := s.store.GetPlansByProductID(id)
+	if err != nil {
+		s.logger.Error("Error fetching plans", zap.Error(err))
+		return nil, err
+	}
+	s.logger.Info("Fetched plans successfully", zap.Int("count", len(plans)))
+	return plans, nil
+}

--- a/lib/services/tvsub/tv_sub_service.go
+++ b/lib/services/tvsub/tv_sub_service.go
@@ -1,0 +1,71 @@
+package tvsub
+
+import (
+	"github.com/aremxyplug-be/db/models"
+	"github.com/aremxyplug-be/db/sqlstore"
+	"go.uber.org/zap"
+)
+
+type TVSubService interface {
+	GetTVSubs(tableName string) ([]models.TVSub, error)
+	CreateTVSub(tableName string, data models.TVSub) (int, error)
+	UpdateTVSub(tableName string, id int, data models.TVSubUpdate) error
+	DeleteTVSub(tableName string, id int) error
+}
+
+type TVSubServiceImpl struct {
+	logger *zap.Logger
+	store  *sqlstore.SqlStore
+}
+
+func NewTVSubService(logger *zap.Logger, store *sqlstore.SqlStore) TVSubService {
+	return &TVSubServiceImpl{
+		logger: logger,
+		store:  store,
+	}
+}
+
+func (s *TVSubServiceImpl) GetTVSubs(tableName string) ([]models.TVSub, error) {
+	s.logger.Info("Fetching TV subscriptions")
+	tvSubs, err := s.store.GetTVSubs(tableName)
+	if err != nil {
+		s.logger.Error("Error fetching TV subscriptions", zap.Error(err))
+		return nil, err
+	}
+	s.logger.Info("Fetched TV subscriptions successfully", zap.Int("count", len(tvSubs)))
+	return tvSubs, nil
+
+}
+
+func (s *TVSubServiceImpl) CreateTVSub(tableName string, data models.TVSub) (int, error) {
+	s.logger.Info("Creating TV subscription")
+	id, err := s.store.CreateTvSub(tableName, data)
+	if err != nil {
+		s.logger.Error("Error creating TV subscription", zap.Error(err))
+		return 0, err
+	}
+	s.logger.Info("Created TV subscription successfully", zap.Int("id", id))
+	return id, nil
+}
+
+func (s *TVSubServiceImpl) UpdateTVSub(tableName string, id int, data models.TVSubUpdate) error {
+	s.logger.Info("Updating TV subscription", zap.Int("id", id))
+	err := s.store.UpdateTvSub(tableName, id, data)
+	if err != nil {
+		s.logger.Error("Error updating TV subscription", zap.Error(err))
+		return err
+	}
+	s.logger.Info("Updated TV subscription successfully", zap.Int("id", id))
+	return nil
+}
+
+func (s *TVSubServiceImpl) DeleteTVSub(tableName string, id int) error {
+	s.logger.Info("Deleting TV subscription", zap.Int("id", id))
+	err := s.store.DeleteTvSub(tableName, id)
+	if err != nil {
+		s.logger.Error("Error deleting TV subscription", zap.Error(err))
+		return err
+	}
+	s.logger.Info("Deleted TV subscription successfully", zap.Int("id", id))
+	return nil
+}

--- a/lib/telcom/data/data.go
+++ b/lib/telcom/data/data.go
@@ -13,9 +13,7 @@ import (
 	"time"
 
 	"github.com/aremxyplug-be/db"
-	"github.com/aremxyplug-be/db/models"
 	"github.com/aremxyplug-be/db/models/telcom"
-	"github.com/aremxyplug-be/db/sqlstore"
 	"github.com/aremxyplug-be/lib/randomgen"
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
@@ -30,16 +28,14 @@ var (
 )
 
 type DataConn struct {
-	Dbconn  db.TelcomStore
-	Logger  *zap.Logger
-	Sqlconn *sqlstore.SqlStore
+	dbConn db.TelcomStore
+	logger *zap.Logger
 }
 
-func NewData(DbConn db.TelcomStore, sqlconn *sqlstore.SqlStore, logger *zap.Logger) *DataConn {
+func NewData(dbConn db.TelcomStore, logger *zap.Logger) *DataConn {
 	return &DataConn{
-		Dbconn:  DbConn,
-		Sqlconn: sqlconn,
-		Logger:  logger,
+		dbConn: dbConn,
+		logger: logger,
 	}
 }
 
@@ -53,7 +49,7 @@ func (d *DataConn) BuyData(data telcom.DataInfo) (*telcom.DataResult, error) {
 	}
 	id, err := randomgen.GenerateOrderID()
 	if err != nil {
-		d.Logger.Error("Could not generate orderID...", zap.Error(err))
+		d.logger.Error("Could not generate orderID...", zap.Error(err))
 		return nil, d.logAndReturnError("Could not generate orderID", err)
 	}
 
@@ -100,13 +96,13 @@ func (d *DataConn) BuyData(data telcom.DataInfo) (*telcom.DataResult, error) {
 			ApiID:           apiResponse.Id,
 		}
 		if err := d.saveTransacation(result); err != nil {
-			d.Logger.Error("Database error try again...", zap.Error(err))
+			d.logger.Error("Database error try again...", zap.Error(err))
 			return nil, errors.New("Database Insert Error...")
 		}
 
 		return result, nil
 	} else {
-		d.Logger.Error("Api Call Error: %s", zap.String("status", fmt.Sprint((resp.Status))))
+		d.logger.Error("Api Call Error: %s", zap.String("status", fmt.Sprint((resp.Status))))
 		body, err := json.Marshal(resp.Body)
 		if err != nil {
 			return nil, err
@@ -127,7 +123,7 @@ func (d *DataConn) BuySpecData(data telcom.SpectranetInfo) (*telcom.SpectranetRe
 	transactionID := randomgen.GenerateTransactionID("dat")
 	resp, err := d.buySpecData(data)
 	if err != nil {
-		d.Logger.Error("error returned from server", zap.Any("error:", err))
+		d.logger.Error("error returned from server", zap.Any("error:", err))
 		return nil, err
 	}
 	defer resp.Body.Close()
@@ -266,7 +262,7 @@ func (d *DataConn) GetAllTransactions() ([]telcom.DataResult, error) {
 	var user string
 	result, err := d.getAllTransactions(user)
 	if err != nil {
-		d.Logger.Error("Database error try again...", zap.Error(err))
+		d.logger.Error("Database error try again...", zap.Error(err))
 		return nil, errors.New("Database request error: " + err.Error())
 	}
 
@@ -287,7 +283,7 @@ func (d *DataConn) GetSpecUserTransactions(username string) ([]telcom.Spectranet
 
 	res, err := d.getAllSpecTransactions(username)
 	if err != nil {
-		d.Logger.Error("Database error try again...", zap.Error(err))
+		d.logger.Error("Database error try again...", zap.Error(err))
 		return nil, errors.New("database request error: " + err.Error())
 	}
 
@@ -298,7 +294,7 @@ func (d *DataConn) GetAllSpecTransactions() ([]telcom.SpectranetResult, error) {
 	var user string
 	result, err := d.getAllSpecTransactions(user)
 	if err != nil {
-		d.Logger.Error("Database error try again...", zap.Error(err))
+		d.logger.Error("Database error try again...", zap.Error(err))
 		return nil, errors.New("Database request error: " + err.Error())
 	}
 
@@ -310,7 +306,7 @@ func (d *DataConn) GetSmileTransDetails(requestID string) (telcom.SmileResult, e
 	res, err := d.getSmileDataDetails(requestID)
 	if err != nil {
 		// write error
-		d.Logger.Error("Database error try again...", zap.Error(err))
+		d.logger.Error("Database error try again...", zap.Error(err))
 		return resp, errors.New("Database request error: " + err.Error())
 	}
 
@@ -322,7 +318,7 @@ func (d *DataConn) GetSmileUserTransactions(username string) ([]telcom.SmileResu
 	res, err := d.getAllSmileTransactions(username)
 	if err != nil {
 		// write error
-		d.Logger.Error("Database error try again...", zap.Error(err))
+		d.logger.Error("Database error try again...", zap.Error(err))
 		return nil, errors.New("database request error: " + err.Error())
 	}
 
@@ -333,7 +329,7 @@ func (d *DataConn) GetAllSmileTransactions() ([]telcom.SmileResult, error) {
 	var user string
 	result, err := d.getAllSmileTransactions(user)
 	if err != nil {
-		d.Logger.Error("Database error try again...", zap.Error(err))
+		d.logger.Error("Database error try again...", zap.Error(err))
 		return nil, errors.New("Database request error: " + err.Error())
 	}
 
@@ -361,56 +357,12 @@ func (d *DataConn) QueryTransaction(id int) error {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		d.Logger.Error("Error querying API...", zap.Error(err))
+		d.logger.Error("Error querying API...", zap.Error(err))
 		return errors.New("Invalid Id...")
 	}
 
 	return nil
 
-}
-func (d *DataConn) GetProductsByID(productID int) ([]models.Product, error) {
-	products, err := d.Sqlconn.GetProducts(productID)
-	if err != nil {
-		d.Logger.Error("Error fetching products by ID", zap.Int("productID", productID), zap.Error(err))
-		return nil, errors.New("failed to fetch products by ID")
-	}
-	return products, nil
-}
-
-func (d *DataConn) AddPlan(plan models.Plan) (int, error) {
-	id, err := d.Sqlconn.CreatePlan(plan)
-	if err != nil {
-		d.Logger.Error("Error adding plan", zap.Any("plan", plan), zap.Error(err))
-		return 0, errors.New("failed to add plan")
-	}
-	return id, nil
-}
-
-func (d *DataConn) DeletePlan(planID int) error {
-	err := d.Sqlconn.DeletePlan(planID)
-	if err != nil {
-		d.Logger.Error("Error deleting plan", zap.Int("planID", planID), zap.Error(err))
-		return errors.New("failed to delete plan")
-	}
-	return nil
-}
-
-func (d *DataConn) UpdatePlan(planID int, plan models.PlanUpdate) error {
-	err := d.Sqlconn.UpdatePlan(planID, plan)
-	if err != nil {
-		d.Logger.Error("Error updating plan", zap.Int("planID", planID), zap.Any("plan", plan), zap.Error(err))
-		return errors.New("failed to update plan")
-	}
-	return nil
-}
-
-func (d *DataConn) GetPlans(productID int) ([]models.Plan, error) {
-	plans, err := d.Sqlconn.GetPlansByProductID(productID)
-	if err != nil {
-		d.Logger.Error("Error fetching plans by product ID", zap.Int("productID", productID), zap.Error(err))
-		return nil, errors.New("failed to fetch plans by product ID")
-	}
-	return plans, nil
 }
 
 func (d *DataConn) buySmileData(data telcom.SmileInfo) (*http.Response, error) {
@@ -427,7 +379,7 @@ func (d *DataConn) buySmileData(data telcom.SmileInfo) (*http.Response, error) {
 
 	req, err := http.NewRequest("POST", url, body)
 	if err != nil {
-		d.Logger.Error("Error creating HTTP request for Smile data", zap.Error(err))
+		d.logger.Error("Error creating HTTP request for Smile data", zap.Error(err))
 		return nil, err
 	}
 	req.Header.Set("api-key", pk)
@@ -437,7 +389,7 @@ func (d *DataConn) buySmileData(data telcom.SmileInfo) (*http.Response, error) {
 	client := &http.Client{}
 	resp, err := client.Do(req)
 	if err != nil {
-		d.Logger.Error("Error sending HTTP request for Smile data", zap.Error(err))
+		d.logger.Error("Error sending HTTP request for Smile data", zap.Error(err))
 		return nil, err
 	}
 
@@ -462,7 +414,7 @@ func (d *DataConn) buySpecData(data telcom.SpectranetInfo) (*http.Response, erro
 
 	req, err := http.NewRequest("POST", url, body)
 	if err != nil {
-		d.Logger.Error("Error creating HTTP request for Spectranet data", zap.Error(err))
+		d.logger.Error("Error creating HTTP request for Spectranet data", zap.Error(err))
 		return nil, err
 	}
 	req.Header.Set("api-key", pk)
@@ -472,7 +424,7 @@ func (d *DataConn) buySpecData(data telcom.SpectranetInfo) (*http.Response, erro
 	client := &http.Client{}
 	resp, err := client.Do(req)
 	if err != nil {
-		d.Logger.Error("Error sending HTTP request for Spectranet data", zap.Error(err))
+		d.logger.Error("Error sending HTTP request for Spectranet data", zap.Error(err))
 		return nil, err
 	}
 
@@ -481,53 +433,53 @@ func (d *DataConn) buySpecData(data telcom.SpectranetInfo) (*http.Response, erro
 
 // saveTransaction saves the details of a transaction to the database
 func (d *DataConn) saveTransacation(details interface{}) error {
-	err := d.Dbconn.SaveDataTransaction(details)
+	err := d.dbConn.SaveDataTransaction(details)
 	if err != nil {
-		d.Logger.Error("Error saving transaction to database", zap.Any("details", details), zap.Error(err))
+		d.logger.Error("Error saving transaction to database", zap.Any("details", details), zap.Error(err))
 	}
 	return err
 }
 
 // getTransactionDetails returns the details of a transaction
 func (d *DataConn) getTransactionDetails(id string) (telcom.DataResult, error) {
-	result, err := d.Dbconn.GetDataTransactionDetails(id)
+	result, err := d.dbConn.GetDataTransactionDetails(id)
 	if err != nil {
-		d.Logger.Error("Error fetching transaction details", zap.String("transactionID", id), zap.Error(err))
+		d.logger.Error("Error fetching transaction details", zap.String("transactionID", id), zap.Error(err))
 	}
 	return result, err
 }
 
 // getAllTransactions returns all transactions. If an empty string is passed, it returns all transactions in the database
 func (d *DataConn) getAllTransactions(username string) ([]telcom.DataResult, error) {
-	results, err := d.Dbconn.GetAllDataTransactions(username)
+	results, err := d.dbConn.GetAllDataTransactions(username)
 	if err != nil {
-		d.Logger.Error("Error fetching all transactions", zap.String("username", username), zap.Error(err))
+		d.logger.Error("Error fetching all transactions", zap.String("username", username), zap.Error(err))
 	}
 	return results, err
 }
 
 // get transactions history
 func (d *DataConn) getSpecDataDetails(requestID string) (telcom.SpectranetResult, error) {
-	result, err := d.Dbconn.GetSpecTransDetails(requestID)
+	result, err := d.dbConn.GetSpecTransDetails(requestID)
 	return result, err
 }
 
 func (d *DataConn) getAllSpecTransactions(username string) ([]telcom.SpectranetResult, error) {
-	result, err := d.Dbconn.GetAllSpecDataTransactions(username)
+	result, err := d.dbConn.GetAllSpecDataTransactions(username)
 	return result, err
 }
 
 func (d *DataConn) getSmileDataDetails(id string) (telcom.SmileResult, error) {
-	result, err := d.Dbconn.GetSmileTransDetails(id)
+	result, err := d.dbConn.GetSmileTransDetails(id)
 	return result, err
 }
 
 func (d *DataConn) getAllSmileTransactions(username string) ([]telcom.SmileResult, error) {
-	result, err := d.Dbconn.GetAllSmileDataTransactions(username)
+	result, err := d.dbConn.GetAllSmileDataTransactions(username)
 	return result, err
 }
 
 func (d *DataConn) logAndReturnError(errorMsg string, err error) error {
-	d.Logger.Error(errorMsg, zap.Error(err))
+	d.logger.Error(errorMsg, zap.Error(err))
 	return errors.New(errorMsg)
 }

--- a/main.go
+++ b/main.go
@@ -67,7 +67,7 @@ func main() {
 	emailClient := postmark.New(secrets)
 	verifyClient := verification.NewVerificationClient(bvnConfig, ninConfig)
 	otp := otpgen.NewOTP(store, logger)
-	data := data.NewData(store, sqlStore, logger)
+	data := data.NewData(store, logger)
 	edu := edu.NewEdu(store, logger)
 	vtu := vtu.NewAirtimeConn(store, logger)
 	tvSub := tvsub.NewTvConn(store, logger)
@@ -84,6 +84,7 @@ func main() {
 
 	config := httpSrv.ServerConfig{
 		Store:        store,
+		SqlStore:     sqlStore,
 		EmailClient:  emailClient,
 		Logger:       logger,
 		Secrets:      secrets,

--- a/server/http/handlers/http_handlers.go
+++ b/server/http/handlers/http_handlers.go
@@ -205,6 +205,18 @@ func (handler *HttpHandler) Login(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	cookie := &http.Cookie{
+		Name:     "refresh_token",
+		Value:    refreshToken,
+		MaxAge:   1800,
+		HttpOnly: true,
+		Secure:   false,
+		Path:     "/",
+		SameSite: http.SameSiteNoneMode,
+	}
+
+	http.SetCookie(w, cookie)
+
 	w.Header().Set("Authorization", jwtToken)
 	w.WriteHeader(http.StatusOK)
 	response := responseFormat.CustomResponse{Status: http.StatusOK, Message: "success", Data: map[string]interface{}{"refresh_token": refreshToken, "customer": userResponse}}

--- a/server/http/handlers/setup.go
+++ b/server/http/handlers/setup.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/aremxyplug-be/db"
+	"github.com/aremxyplug-be/db/sqlstore"
 	auth_pin "github.com/aremxyplug-be/lib/auth/pin"
 	bankacc "github.com/aremxyplug-be/lib/bank/bank_acc"
 	"github.com/aremxyplug-be/lib/bank/deposit"
@@ -16,6 +17,9 @@ import (
 	otpgen "github.com/aremxyplug-be/lib/otp_gen"
 	pointredeem "github.com/aremxyplug-be/lib/point-redeem"
 	"github.com/aremxyplug-be/lib/referral"
+	"github.com/aremxyplug-be/lib/services"
+	telecomservice "github.com/aremxyplug-be/lib/services/telcom"
+	tvservice "github.com/aremxyplug-be/lib/services/tvsub"
 	"github.com/aremxyplug-be/lib/smsclient/termii"
 	"github.com/aremxyplug-be/lib/telcom/airtime"
 	"github.com/aremxyplug-be/lib/telcom/data"
@@ -70,11 +74,13 @@ type HttpHandler struct {
 	pin                  *auth_pin.PinConfig
 	smsClient            *termii.SMSConn
 	verifyClient         verification.VerificationClient
+	productClient        services.ProductService
 }
 
 type HandlerOptions struct {
 	Logger       *zap.Logger
 	Store        db.DataStore
+	SqlStore     *sqlstore.SqlStore
 	Data         *data.DataConn
 	Edu          *edu.EduConn
 	VTU          *airtime.AirtimeConn
@@ -120,6 +126,14 @@ func NewHttpHandler(opt *HandlerOptions) *HttpHandler {
 		)
 	}
 
+	tvSubService := tvservice.NewTVSubService(opt.Logger, opt.SqlStore)
+	telecomService := telecomservice.NewTelecomService(opt.SqlStore, opt.Logger)
+
+	productService := &services.ProductServiceImpl{
+		TVSubService:    tvSubService,
+		TelecomProducts: telecomService,
+	}
+
 	return &HttpHandler{
 		logger:      opt.Logger,
 		idGenerator: idgenerator.New(),
@@ -149,5 +163,6 @@ func NewHttpHandler(opt *HandlerOptions) *HttpHandler {
 		point:                opt.Point,
 		smsClient:            opt.SMSClient,
 		verifyClient:         opt.VerifyClient,
+		productClient:        productService,
 	}
 }

--- a/server/http/handlers/telcom_handlers.go
+++ b/server/http/handlers/telcom_handlers.go
@@ -555,11 +555,11 @@ func (handler *HttpHandler) GetSmileTransactions(w http.ResponseWriter, r *http.
 
 func (handler *HttpHandler) TelcomProducts(w http.ResponseWriter, r *http.Request) {
 
-	id := chi.URLParam(r, "productID")
+	id := chi.URLParam(r, "networkID")
 
-	productID, _ := strconv.Atoi(id)
+	networkID, _ := strconv.Atoi(id)
 
-	products, err := handler.dataClient.GetProductsByID(productID)
+	products, err := handler.productClient.GetProducts(networkID)
 	if err != nil {
 		handler.logger.Error("Failed to retrieve products", zap.Error(err))
 		w.WriteHeader(http.StatusInternalServerError)
@@ -599,7 +599,7 @@ func (handler *HttpHandler) TelecomPlans(w http.ResponseWriter, r *http.Request)
 			return
 		}
 
-		createdPlan, err := handler.dataClient.AddPlan(newPlan)
+		createdPlan, err := handler.productClient.CreatePlan(newPlan)
 		if err != nil {
 			w.WriteHeader(http.StatusInternalServerError)
 			handler.logger.Error("Failed to create plan", zap.Error(err))
@@ -628,7 +628,7 @@ func (handler *HttpHandler) TelecomPlans(w http.ResponseWriter, r *http.Request)
 
 		productID, _ := strconv.Atoi(id)
 
-		plans, err := handler.dataClient.GetPlans(productID)
+		plans, err := handler.productClient.GetPlans(productID)
 		if err != nil {
 			handler.logger.Error("Failed to retrieve plans", zap.Error(err))
 			w.WriteHeader(http.StatusInternalServerError)
@@ -650,7 +650,7 @@ func (handler *HttpHandler) TelecomPlans(w http.ResponseWriter, r *http.Request)
 		json.NewEncoder(w).Encode(response)
 	}
 
-	if r.Method == "PUT" {
+	if r.Method == "PATCH" {
 
 		id := chi.URLParam(r, "planID")
 		planID, _ := strconv.Atoi(id)
@@ -669,7 +669,7 @@ func (handler *HttpHandler) TelecomPlans(w http.ResponseWriter, r *http.Request)
 			return
 		}
 
-		if err := handler.dataClient.UpdatePlan(planID, updatedPlan); err != nil {
+		if err := handler.productClient.UpdatePlan(planID, updatedPlan); err != nil {
 			w.WriteHeader(http.StatusInternalServerError)
 			handler.logger.Error("Failed to update plan", zap.Error(err))
 			response := responseFormat.CustomResponse{
@@ -684,7 +684,10 @@ func (handler *HttpHandler) TelecomPlans(w http.ResponseWriter, r *http.Request)
 		response := responseFormat.CustomResponse{
 			Status:  http.StatusOK,
 			Message: "success",
-			Data:    map[string]interface{}{"updated_plan": updatedPlan},
+			Data: map[string]interface{}{
+				"updated_plan": updatedPlan,
+				"message":      fmt.Sprintf("Plan with ID %d updated successfully", planID),
+			},
 		}
 		json.NewEncoder(w).Encode(response)
 
@@ -692,7 +695,7 @@ func (handler *HttpHandler) TelecomPlans(w http.ResponseWriter, r *http.Request)
 
 	if r.Method == "DELETE" {
 
-		id := chi.URLParam(r, "plaID")
+		id := chi.URLParam(r, "planID")
 
 		planID, err := strconv.Atoi(id)
 		if err != nil {
@@ -707,7 +710,7 @@ func (handler *HttpHandler) TelecomPlans(w http.ResponseWriter, r *http.Request)
 			return
 		}
 
-		if err := handler.dataClient.DeletePlan(planID); err != nil {
+		if err := handler.productClient.DeletePlan(planID); err != nil {
 			w.WriteHeader(http.StatusInternalServerError)
 			handler.logger.Error("Failed to delete plan", zap.Error(err))
 			response := responseFormat.CustomResponse{

--- a/server/http/handlers/utilies_handlers.go
+++ b/server/http/handlers/utilies_handlers.go
@@ -320,3 +320,242 @@ func (handler *HttpHandler) GetElectricBillDetails(w http.ResponseWriter, r *htt
 
 	json.NewEncoder(w).Encode(res)
 }
+
+func (handler *HttpHandler) TvSubHandler(w http.ResponseWriter, r *http.Request) {
+	// Extract the product type from the URL path
+	product := chi.URLParam(r, "product")
+
+	// Validate the product type
+	validProducts := map[string]bool{
+		"dstv":      true,
+		"gotv":      true,
+		"showmax":   true,
+		"startimes": true,
+	}
+
+	if !validProducts[product] {
+		w.WriteHeader(http.StatusBadRequest)
+		handler.logger.Error("Invalid product type")
+		response := responseFormat.CustomResponse{
+			Status:  http.StatusBadRequest,
+			Message: "error",
+			Data:    map[string]interface{}{"data": fmt.Sprintf("Invalid product type: %s", product)},
+		}
+		json.NewEncoder(w).Encode(response)
+		return
+	}
+
+	// Handle different HTTP methods
+	switch r.Method {
+	case "POST":
+		handler.handleCreateTVSub(w, r, product)
+	case "GET":
+		handler.handleGetTVSubs(w, product)
+	case "PATCH":
+		handler.handleUpdateTVSub(w, r, product)
+	case "DELETE":
+		handler.handleDeleteTVSub(w, r, product)
+	default:
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		response := responseFormat.CustomResponse{
+			Status:  http.StatusMethodNotAllowed,
+			Message: "error",
+			Data:    map[string]interface{}{"data": "Method not allowed"},
+		}
+		json.NewEncoder(w).Encode(response)
+	}
+}
+
+func (handler *HttpHandler) handleCreateTVSub(w http.ResponseWriter, r *http.Request, product string) {
+	data := models.TVSub{}
+
+	if err := json.NewDecoder(r.Body).Decode(&data); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		handler.logger.Error("Decoding JSON response", zap.Error(err))
+		response := responseFormat.CustomResponse{
+			Status:  http.StatusBadRequest,
+			Message: "error",
+			Data:    map[string]interface{}{"data": fmt.Sprintf("Failed to decode request body: %s", err.Error())},
+		}
+		json.NewEncoder(w).Encode(response)
+		return
+	}
+
+	if data.Package == "" || data.PackageName == "" {
+		w.WriteHeader(http.StatusBadRequest)
+		handler.logger.Error("Missing required fields")
+		response := responseFormat.CustomResponse{
+			Status:  http.StatusBadRequest,
+			Message: "error",
+			Data:    map[string]interface{}{"data": "Package and package name are required"},
+		}
+		json.NewEncoder(w).Encode(response)
+		return
+	}
+
+	if data.Amount <= 0 {
+		w.WriteHeader(http.StatusBadRequest)
+		handler.logger.Error("Invalid amount")
+		response := responseFormat.CustomResponse{
+			Status:  http.StatusBadRequest,
+			Message: "error",
+			Data:    map[string]interface{}{"data": "Amount must be greater than zero"},
+		}
+		json.NewEncoder(w).Encode(response)
+		return
+	}
+
+	ID, err := handler.productClient.CreateTVSub(product, data)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		handler.logger.Error("Error creating TV subscription", zap.Error(err))
+		response := responseFormat.CustomResponse{
+			Status:  http.StatusInternalServerError,
+			Message: "error",
+			Data:    map[string]interface{}{"data": fmt.Sprintf("Failed to create TV subscription: %s", err.Error())},
+		}
+		json.NewEncoder(w).Encode(response)
+		return
+	}
+
+	w.WriteHeader(http.StatusCreated)
+	handler.logger.Info("TV subscription created successfully", zap.Int("ID", ID))
+	response := responseFormat.CustomResponse{
+		Status:  http.StatusCreated,
+		Message: "success",
+		Data:    map[string]interface{}{"data": fmt.Sprintf("TV subscription created successfully with ID %d", ID)},
+	}
+	json.NewEncoder(w).Encode(response)
+}
+
+func (handler *HttpHandler) handleGetTVSubs(w http.ResponseWriter, product string) {
+	res, err := handler.productClient.GetTVSubs(product)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		handler.logger.Error("Error fetching TV subscriptions", zap.Error(err))
+		response := responseFormat.CustomResponse{
+			Status:  http.StatusInternalServerError,
+			Message: "error",
+			Data:    map[string]interface{}{"data": fmt.Sprintf("Failed to fetch TV subscriptions: %s", err.Error())},
+		}
+		json.NewEncoder(w).Encode(response)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	response := responseFormat.CustomResponse{
+		Status:  http.StatusOK,
+		Message: "success",
+		Data:    map[string]interface{}{"data": res},
+	}
+	json.NewEncoder(w).Encode(response)
+}
+
+func (handler *HttpHandler) handleUpdateTVSub(w http.ResponseWriter, r *http.Request, product string) {
+	id := chi.URLParam(r, "id")
+	if id == "" {
+		w.WriteHeader(http.StatusBadRequest)
+		handler.logger.Error("Missing ID parameter")
+		response := responseFormat.CustomResponse{
+			Status:  http.StatusBadRequest,
+			Message: "error",
+			Data:    map[string]interface{}{"data": "ID parameter is required"},
+		}
+		json.NewEncoder(w).Encode(response)
+		return
+	}
+	subID, _ := strconv.Atoi(id)
+	if subID <= 0 {
+		w.WriteHeader(http.StatusBadRequest)
+		handler.logger.Error("Invalid ID parameter")
+		response := responseFormat.CustomResponse{
+			Status:  http.StatusBadRequest,
+			Message: "error",
+			Data:    map[string]interface{}{"data": "ID must be a positive integer"},
+		}
+		json.NewEncoder(w).Encode(response)
+		return
+	}
+
+	data := models.TVSubUpdate{}
+	if err := json.NewDecoder(r.Body).Decode(&data); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		handler.logger.Error("Decoding JSON response", zap.Error(err))
+		response := responseFormat.CustomResponse{
+			Status:  http.StatusBadRequest,
+			Message: "error",
+			Data:    map[string]interface{}{"data": fmt.Sprintf("Failed to decode request body: %s", err.Error())},
+		}
+		json.NewEncoder(w).Encode(response)
+		return
+	}
+
+	err := handler.productClient.UpdateTVSub(product, subID, data)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		handler.logger.Error("Error updating TV subscription", zap.Error(err))
+		response := responseFormat.CustomResponse{
+			Status:  http.StatusInternalServerError,
+			Message: "error",
+			Data:    map[string]interface{}{"data": fmt.Sprintf("Failed to update TV subscription: %s", err.Error())},
+		}
+		json.NewEncoder(w).Encode(response)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	response := responseFormat.CustomResponse{
+		Status:  http.StatusOK,
+		Message: "success",
+		Data:    map[string]interface{}{"data": fmt.Sprintf("TV subscription with ID %d updated successfully", subID)},
+	}
+	json.NewEncoder(w).Encode(response)
+}
+
+func (handler *HttpHandler) handleDeleteTVSub(w http.ResponseWriter, r *http.Request, product string) {
+	id := chi.URLParam(r, "id")
+	if id == "" {
+		w.WriteHeader(http.StatusBadRequest)
+		handler.logger.Error("Missing ID parameter")
+		response := responseFormat.CustomResponse{
+			Status:  http.StatusBadRequest,
+			Message: "error",
+			Data:    map[string]interface{}{"data": "ID parameter is required"},
+		}
+		json.NewEncoder(w).Encode(response)
+		return
+	}
+	subID, _ := strconv.Atoi(id)
+	if subID <= 0 {
+		w.WriteHeader(http.StatusBadRequest)
+		handler.logger.Error("Invalid ID parameter")
+		response := responseFormat.CustomResponse{
+			Status:  http.StatusBadRequest,
+			Message: "error",
+			Data:    map[string]interface{}{"data": "ID must be a positive integer"},
+		}
+		json.NewEncoder(w).Encode(response)
+		return
+	}
+
+	err := handler.productClient.DeleteTVSub(product, subID)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		handler.logger.Error("Error deleting TV subscription", zap.Error(err))
+		response := responseFormat.CustomResponse{
+			Status:  http.StatusInternalServerError,
+			Message: "error",
+			Data:    map[string]interface{}{"data": fmt.Sprintf("Failed to delete TV subscription: %s", err.Error())},
+		}
+		json.NewEncoder(w).Encode(response)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	response := responseFormat.CustomResponse{
+		Status:  http.StatusOK,
+		Message: "success",
+		Data:    map[string]interface{}{"data": fmt.Sprintf("TV subscription with ID %d deleted successfully", subID)},
+	}
+	json.NewEncoder(w).Encode(response)
+}

--- a/server/http/http.go
+++ b/server/http/http.go
@@ -3,6 +3,7 @@ package http
 import (
 	"net/http"
 
+	"github.com/aremxyplug-be/db/sqlstore"
 	"github.com/aremxyplug-be/lib/auth"
 	auth_pin "github.com/aremxyplug-be/lib/auth/pin"
 	bankacc "github.com/aremxyplug-be/lib/bank/bank_acc"
@@ -34,6 +35,7 @@ import (
 type ServerConfig struct {
 	Logger       *zap.Logger
 	Store        db.DataStore
+	SqlStore     *sqlstore.SqlStore
 	Secrets      *config.Secrets
 	EmailClient  emailclient.EmailClient
 	DataClient   *data.DataConn
@@ -75,6 +77,7 @@ func MountServer(config ServerConfig) *chi.Mux {
 	httpHandler := handlers.NewHttpHandler(&handlers.HandlerOptions{
 		Logger:       config.Logger,
 		Store:        config.Store,
+		SqlStore:     config.SqlStore,
 		Secrets:      config.Secrets,
 		EmailClient:  config.EmailClient,
 		Data:         config.DataClient,
@@ -115,13 +118,6 @@ func MountServer(config ServerConfig) *chi.Mux {
 
 		verifyOTPRoutes(router, httpHandler)
 
-		// // test
-		// router.Post("/test", httpHandler.Testtoken)
-
-		// router.Get("/banks", httpHandler.GetBanks)
-
-		// router.Get("/deposit", httpHandler.DepositAccount)
-
 		authRouter := router.With(config.Auth.Authorize)
 		// reset password
 		authRouter.Patch("/reset-password", httpHandler.ResetPassword)
@@ -159,15 +155,10 @@ func MountServer(config ServerConfig) *chi.Mux {
 
 		getBalance(authRouter, httpHandler)
 
-		telcomRoutes(authRouter, httpHandler)
-
 		checkVerification(authRouter, httpHandler)
 
-		/*
-			transferMoneyRoutes(authRouter, httpHandler)
+		productRoutes(authRouter, httpHandler)
 
-			depositRoutes(authRouter, httpHandler)
-		*/
 	})
 
 	return router
@@ -340,30 +331,29 @@ func getBalance(r chi.Router, httpHandler *handlers.HttpHandler) {
 	})
 }
 
-func telcomRoutes(router chi.Router, httpHandler *handlers.HttpHandler) {
-	router.Route("/products", func(r chi.Router) {
-		r.Post("/", httpHandler.TelcomProducts)
-	})
-
-	router.Route("/plans", func(r chi.Router) {
-		r.Post("/", httpHandler.TelecomPlans)
-		r.Get("/{productID}", httpHandler.TelecomPlans)
-		r.Put("/{planID}", httpHandler.TelecomPlans)
-		r.Delete("/{planID}", httpHandler.TelecomPlans)
-	})
-}
-
 func checkVerification(router chi.Router, httpHandler *handlers.HttpHandler) {
 	router.Route("/check-verification", func(r chi.Router) {
 		r.Get("/", httpHandler.CheckVerification)
 	})
 }
 
-/*
-func depositRoutes(r chi.Router, httpHandler *handlers.HttpHandler) {
-	r.Route("/deposit", func(router chi.Router) {
-		router.Get("/", httpHandler.GetDepositHistory)
-		router.Get("/{id}", httpHandler.GetDepositDetail)
+func productRoutes(r chi.Router, httpHandler *handlers.HttpHandler) {
+	r.Route("/products", func(router chi.Router) {
+		// TV Subscription Routes
+		router.Route("/tvsub/{product}", func(router chi.Router) {
+			router.Post("/", httpHandler.TvSubHandler)       // POST /tvsub/dstv
+			router.Get("/", httpHandler.TvSubHandler)        // GET /tvsub/dstv (all subscriptions)
+			router.Patch("/{id}", httpHandler.TvSubHandler)  // PATCH /tvsub/dstv/2
+			router.Delete("/{id}", httpHandler.TvSubHandler) // DELETE /tvsub/dstv/2
+		})
+
+		// Telecom Plans Routes
+		router.Route("/telecom", func(router chi.Router) {
+			router.Get("/list/{networkID}", httpHandler.TelcomProducts)
+			router.Post("/", httpHandler.TelecomPlans)
+			router.Get("/{productID}", httpHandler.TelecomPlans)
+			router.Patch("/{planID}", httpHandler.TelecomPlans)
+			router.Delete("/{planID}", httpHandler.TelecomPlans)
+		})
 	})
 }
-*/


### PR DESCRIPTION
feat(auth): Enhance authorization middleware to support refresh tokens and generate new auth tokens

feat(services): Introduce ProductService and implement Telecom and TV Subscription services

feat(telcom): Implement Telecom service with CRUD operations for plans and products

feat(tvsub): Create TV Subscription service with CRUD operations

refactor(telcom/data): Simplify DataConn structure and remove unused SQL store references

fix(main): Update DataConn initialization to remove SQL store dependency

feat(http): Add new routes for TV subscriptions and telecom products with appropriate handlers

feat(handlers): Implement TV subscription management handlers for create, read, update, and delete operations