### PR TITLE
refactor(handlers): remove unused http.Request param from addevent method

### DIFF
--- a/db/mongo/tasks.go
+++ b/db/mongo/tasks.go
@@ -49,7 +49,6 @@ func (m *mongoStore) IncrementCumulative(userID string, def models.TaskDef, delt
 		"$setOnInsert": bson.M{
 			"created_at":       now,
 			"completed":        false,
-			"progress":         0, // $inc will add delta
 			"processed_tx_ids": []string{},
 		},
 	}
@@ -61,8 +60,6 @@ func (m *mongoStore) IncrementCumulative(userID string, def models.TaskDef, delt
 	opts := options.FindOneAndUpdate().SetUpsert(true).SetReturnDocument(options.After)
 	var doc models.ProgressDoc
 	if err := m.col(tasksColl).FindOneAndUpdate(ctx, filter, update, opts).Decode(&doc); err != nil {
-		// If we get a duplicate key error, it means the document exists but our filter (txID check) failed.
-		// This implies the transaction was already processed. Return the existing document.
 		if mongo.IsDuplicateKeyError(err) {
 			return m.GetProgress(userID, def.Code)
 		}

--- a/server/http/handlers/extras_handlers.go
+++ b/server/http/handlers/extras_handlers.go
@@ -124,7 +124,7 @@ func (handler *HttpHandler) Points(w http.ResponseWriter, r *http.Request) {
 		}
 
 		handler.logger.Info("Processing point redeemed event", zap.String("user_id", user.ID), zap.Int("points_redeemed", pointsToRedeem.Point))
-		handler.addevent(r, user.ID, receipt.Amount_Redeemed, receipt.TransactionID, "points.redeemed")
+		handler.addevent(user.ID, receipt.Amount_Redeemed, receipt.TransactionID, "points.redeemed")
 
 		handler.logger.Info("Points redeemed successfully", zap.Any("receipt", receipt))
 		response := responseFormat.CustomResponse{Status: http.StatusOK, Message: "success", Data: map[string]interface{}{"data": receipt}}
@@ -218,7 +218,9 @@ func (handler *HttpHandler) Pin(w http.ResponseWriter, r *http.Request) {
 			handler.logger.Warn("failed to add points and update transaction time", zap.Error(err))
 		}
 
-		handler.addevent(r, user.ID, "", "", "signup.completed")
+		if handler.processor != nil {
+			handler.addevent(user.ID, "", "", "signup.completed")
+		}
 
 		w.WriteHeader(http.StatusCreated)
 		handler.logger.Info("User pin created successfully", zap.String("user_id", user.ID))

--- a/server/http/handlers/telcom_handlers.go
+++ b/server/http/handlers/telcom_handlers.go
@@ -180,7 +180,7 @@ func (handler *HttpHandler) Airtime(w http.ResponseWriter, r *http.Request) {
 
 			// Emit utility.payment event
 			if handler.processor != nil {
-				handler.addevent(r, id, data.Amount, res.TransactionID, "airtime.purchase")
+				handler.addevent(id, data.Amount, res.TransactionID, "airtime.purchase")
 			}
 
 			w.WriteHeader(http.StatusOK)
@@ -545,7 +545,7 @@ func (handler *HttpHandler) Data(w http.ResponseWriter, r *http.Request) {
 
 			// Emit utility.payment event
 			if handler.processor != nil {
-				handler.addevent(r, id, data.Amount, res.TransactionID, "data.purchase")
+				handler.addevent(id, data.Amount, res.TransactionID, "data.purchase")
 			}
 
 			w.WriteHeader(http.StatusOK)

--- a/server/http/handlers/utilies_handlers.go
+++ b/server/http/handlers/utilies_handlers.go
@@ -173,7 +173,7 @@ func (handler *HttpHandler) EduPins(w http.ResponseWriter, r *http.Request) {
 
 			// Emit utility.payment event
 			if handler.processor != nil {
-				handler.addevent(r, id, data.Amount, res.TransactionID, "purchase.completed")
+				handler.addevent(id, data.Amount, res.TransactionID, "purchase.completed")
 			}
 
 			w.WriteHeader(http.StatusOK)
@@ -425,11 +425,6 @@ func (handler *HttpHandler) TVSubscriptions(w http.ResponseWriter, r *http.Reque
 				handler.logger.Warn("failed to add points and update transaction time", zap.Error(err))
 			}
 
-			// Emit utility.payment event
-			if handler.processor != nil {
-				handler.addevent(r, id, strconv.Itoa(data.Amount), res.TransactionID, "purchase.completed")
-			}
-
 			w.WriteHeader(http.StatusOK)
 			handler.logger.Info("TV subscription processed successfully", zap.Any("response", res))
 			response := responseFormat.CustomResponse{
@@ -656,10 +651,6 @@ func (handler *HttpHandler) ElectricBill(w http.ResponseWriter, r *http.Request)
 				handler.logger.Warn("failed to add points and update transaction time", zap.Error(err))
 			}
 
-			if handler.processor != nil {
-				handler.addevent(r, id, strconv.Itoa(data.Amount), res.TransactionID, "purchase.completed")
-			}
-
 			w.WriteHeader(http.StatusOK)
 			handler.logger.Info("Electricity subscription processed successfully", zap.Any("response", res))
 			response := responseFormat.CustomResponse{
@@ -815,7 +806,7 @@ func (handler *HttpHandler) TvSubHandler(w http.ResponseWriter, r *http.Request)
 	}
 }
 
-func (handler *HttpHandler) addevent(r *http.Request, usedID string, amt string, txnID string, eventType string) {
+func (handler *HttpHandler) addevent(usedID string, amt string, txnID string, eventType string) {
 	if handler.processor != nil {
 		go func(uID string, amt string, txID string, eType string) {
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)


### PR DESCRIPTION
Simplify event handling by removing unused request parameter from addevent calls across multiple handlers. Also clean up redundant event emission checks and remove unnecessary progress field in mongo task increment