### PR TITLE
fix(deposit): skip small deposits and format amount before event

### DIFF
--- a/lib/bank/deposit/deposit.go
+++ b/lib/bank/deposit/deposit.go
@@ -164,10 +164,16 @@ func (c *Config) Deposit(virtualaccountid string, userID string) (updated bool, 
 
 		updatedAny = true
 
-		// Emit wallet.funded event
-		if c.processor != nil {
-			go func(uID string, amt string, txID string) {
-				if amt >= "100" {
+		amount := ""
+		if deposit_amount < 100 {
+			continue
+		} else {
+			amount = fmt.Sprintf("%.2f", deposit_amount)
+
+			// Emit wallet.funded event
+			if c.processor != nil {
+				go func(uID string, amt string, txID string) {
+
 					ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 					defer cancel()
 					ev := &events.Event{
@@ -181,8 +187,9 @@ func (c *Config) Deposit(virtualaccountid string, userID string) (updated bool, 
 					if err := c.processor.ProcessEvent(ctx, ev); err != nil {
 						c.logger.Error("failed to process wallet.funded event", zap.Error(err), zap.String("user_id", uID))
 					}
-				}
-			}(userID, depositAmount.String(), transctionID)
+
+				}(userID, amount, transctionID)
+			}
 		}
 	}
 


### PR DESCRIPTION
Only emit wallet.funded event for deposits >= 100 and format the amount to 2 decimal places. This prevents processing insignificant amounts and ensures consistent amount formatting in events.