### PR TITLE
fix(deposit): correct service charge calculation for minor amounts

### DIFF
--- a/lib/bank/deposit/charges.go
+++ b/lib/bank/deposit/charges.go
@@ -33,7 +33,7 @@ func (c *Config) CalculateDepositBreakdown(ctx context.Context, amountMinor floa
 		return ChargeBreakdown{}, fmt.Errorf("wallet charges configuration is incomplete")
 	}
 
-	grossAmount := decimal.NewFromFloatWithExponent(amountMinor, -2)
+	grossAmount := decimal.NewFromFloat(amountMinor).Div(decimal.NewFromInt(100)).Round(2)
 	serviceChargeRate := decimal.NewFromFloat(*charges.ServiceCharge)
 	serviceChargeCap := decimal.NewFromFloat(*charges.ServiceChargeCap).Round(2)
 	serviceChargeApplied := grossAmount.Mul(serviceChargeRate).Div(decimal.NewFromInt(100)).Round(2)


### PR DESCRIPTION
Use decimal division instead of exponent scaling to avoid precision loss when converting minor amounts to major currency units. This ensures accurate service charge calculations for all deposit amounts.