### PR TITLE
fix(bank): ensure goroutine event processing uses independent context

### DIFF
--- a/lib/bank/deposit/deposit.go
+++ b/lib/bank/deposit/deposit.go
@@ -191,8 +191,13 @@ func (c *Config) Deposit(ctx context.Context, virtualaccountid string, userID st
 			// Emit wallet.funded event
 			if c.processor != nil {
 				go func(uID string, amt string, txID string) {
+					baseCtx := ctx
+					if baseCtx == nil {
+						baseCtx = context.Background()
+					}
+					baseCtx = context.WithoutCancel(baseCtx)
 
-					ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+					taskCtx, cancel := context.WithTimeout(baseCtx, 10*time.Second)
 					defer cancel()
 					ev := &events.Event{
 						Type:      "wallet.funded",
@@ -202,7 +207,7 @@ func (c *Config) Deposit(ctx context.Context, virtualaccountid string, userID st
 						TS:        time.Now().UTC(),
 						Published: false,
 					}
-					if err := c.processor.ProcessEvent(ctx, ev); err != nil {
+					if err := c.processor.ProcessEvent(taskCtx, ev); err != nil {
 						c.logger.Error("failed to process wallet.funded event", zap.Error(err), zap.String("user_id", uID))
 					}
 

--- a/lib/bank/transfer/transfer.go
+++ b/lib/bank/transfer/transfer.go
@@ -172,7 +172,13 @@ func (c *Config) TransferToAremxyPlug(ctx context.Context, data AremxyPlugTransf
 	if c.processor != nil {
 		// Process deposit event for receiver
 		go func(uID string, amt string, txID string) {
-			ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+			baseCtx := ctx
+			if baseCtx == nil {
+				baseCtx = context.Background()
+			}
+			baseCtx = context.WithoutCancel(baseCtx)
+
+			taskCtx, cancel := context.WithTimeout(baseCtx, 10*time.Second)
 			defer cancel()
 			ev := &events.Event{
 				Type:      "transaction.completed",
@@ -182,14 +188,20 @@ func (c *Config) TransferToAremxyPlug(ctx context.Context, data AremxyPlugTransf
 				TS:        time.Now().UTC(),
 				Published: false,
 			}
-			if err := c.processor.ProcessEvent(ctx, ev); err != nil {
+			if err := c.processor.ProcessEvent(taskCtx, ev); err != nil {
 				c.logger.Error("failed to process transaction.completed event", zap.Error(err), zap.String("user_id", uID))
 			}
 		}(user.ID, fmt.Sprintf("%v", data.Amount), depTransactionID)
 
 		// Process transfer event for sender
 		go func(uID string, amt string, txID string) {
-			ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+			baseCtx := ctx
+			if baseCtx == nil {
+				baseCtx = context.Background()
+			}
+			baseCtx = context.WithoutCancel(baseCtx)
+
+			taskCtx, cancel := context.WithTimeout(baseCtx, 10*time.Second)
 			defer cancel()
 			ev := &events.Event{
 				Type:      "transaction.completed",
@@ -199,7 +211,7 @@ func (c *Config) TransferToAremxyPlug(ctx context.Context, data AremxyPlugTransf
 				TS:        time.Now().UTC(),
 				Published: false,
 			}
-			if err := c.processor.ProcessEvent(ctx, ev); err != nil {
+			if err := c.processor.ProcessEvent(taskCtx, ev); err != nil {
 				c.logger.Error("failed to process transaction.completed event", zap.Error(err), zap.String("user_id", uID))
 			}
 		}(data.UserID, fmt.Sprintf("%v", data.Amount), trfTransactionID)


### PR DESCRIPTION
The existing code reused the parent context `ctx` inside goroutines, which could lead to premature cancellation if the parent context was cancelled before the goroutine completed. This change creates a new base context using `context.WithoutCancel` to decouple the event processing lifecycle from the incoming request. It also guards against a nil context by falling back to `context.Background()`.