### PR TITLE
feat(auth): add login email allowlist

### DIFF
--- a/config/secret.go
+++ b/config/secret.go
@@ -24,6 +24,8 @@ type Secrets struct {
 	ServiceID            string `json:"TWILIO_SERVICES_ID"`
 	SignupAllowedEmails  string `json:"SIGNUP_ALLOWED_EMAILS"`
 	SignupAllowedFile    string `json:"SIGNUP_ALLOWED_EMAILS_FILE"`
+	LoginAllowedEmails   string `json:"LOGIN_ALLOWED_EMAILS"`
+	LoginAllowedFile     string `json:"LOGIN_ALLOWED_EMAILS_FILE"`
 }
 
 var ss Secrets
@@ -48,6 +50,8 @@ func init() {
 	ss.AppPort = os.Getenv("PORT")
 	ss.SignupAllowedEmails = os.Getenv("SIGNUP_ALLOWED_EMAILS")
 	ss.SignupAllowedFile = os.Getenv("SIGNUP_ALLOWED_EMAILS_FILE")
+	ss.LoginAllowedEmails = os.Getenv("LOGIN_ALLOWED_EMAILS")
+	ss.LoginAllowedFile = os.Getenv("LOGIN_ALLOWED_EMAILS_FILE")
 
 	if ss.AppPort = os.Getenv("PORT"); ss.AppPort == "" {
 		ss.AppPort = "8080"

--- a/server/http/handlers/http_handlers.go
+++ b/server/http/handlers/http_handlers.go
@@ -52,6 +52,11 @@ func (handler *HttpHandler) initSignupAllowlist() {
 	rawFile := strings.TrimSpace(handler.secrets.SignupAllowedFile)
 
 	if rawList == "" && rawFile == "" {
+		rawList = strings.TrimSpace(handler.secrets.LoginAllowedEmails)
+		rawFile = strings.TrimSpace(handler.secrets.LoginAllowedFile)
+	}
+
+	if rawList == "" && rawFile == "" {
 		return
 	}
 
@@ -100,6 +105,62 @@ func (handler *HttpHandler) isSignupEmailAllowed(email string) (bool, error) {
 	}
 	email = strings.ToLower(strings.TrimSpace(email))
 	_, ok := handler.signupAllowlist[email]
+	return ok, nil
+}
+
+func (handler *HttpHandler) initLoginAllowlist() {
+	rawList := strings.TrimSpace(handler.secrets.LoginAllowedEmails)
+	rawFile := strings.TrimSpace(handler.secrets.LoginAllowedFile)
+
+	if rawList == "" && rawFile == "" {
+		return
+	}
+
+	allowlist := map[string]struct{}{}
+
+	if rawList != "" {
+		for _, email := range splitAllowlistEmails(rawList) {
+			email = strings.ToLower(strings.TrimSpace(email))
+			if email == "" {
+				continue
+			}
+			allowlist[email] = struct{}{}
+		}
+	}
+
+	if rawFile != "" {
+		b, err := os.ReadFile(rawFile)
+		if err != nil {
+			handler.loginAllowlistErr = err
+			return
+		}
+		for _, email := range splitAllowlistEmails(string(b)) {
+			email = strings.ToLower(strings.TrimSpace(email))
+			if email == "" {
+				continue
+			}
+			allowlist[email] = struct{}{}
+		}
+	}
+
+	if len(allowlist) == 0 {
+		handler.loginAllowlistErr = errors.New("login allowlist is configured but empty")
+		return
+	}
+
+	handler.loginAllowlist = allowlist
+}
+
+func (handler *HttpHandler) isLoginEmailAllowed(email string) (bool, error) {
+	handler.loginAllowlistOnce.Do(handler.initLoginAllowlist)
+	if handler.loginAllowlistErr != nil {
+		return false, handler.loginAllowlistErr
+	}
+	if handler.loginAllowlist == nil {
+		return true, nil
+	}
+	email = strings.ToLower(strings.TrimSpace(email))
+	_, ok := handler.loginAllowlist[email]
 	return ok, nil
 }
 
@@ -268,6 +329,29 @@ func (handler *HttpHandler) Login(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		w.WriteHeader(http.StatusNotFound)
 		response := responseFormat.CustomResponse{Status: http.StatusNotFound, Message: "user not found", Data: map[string]interface{}{"data": "user not found"}}
+		json.NewEncoder(w).Encode(response)
+		return
+	}
+
+	allowed, allowErr := handler.isLoginEmailAllowed(user.Email)
+	if allowErr != nil {
+		handler.logger.Error("login allowlist error", zap.Error(allowErr))
+		w.WriteHeader(http.StatusInternalServerError)
+		response := responseFormat.CustomResponse{
+			Status:  http.StatusInternalServerError,
+			Message: "error",
+			Data:    map[string]interface{}{"data": "login temporarily unavailable"},
+		}
+		json.NewEncoder(w).Encode(response)
+		return
+	}
+	if !allowed {
+		w.WriteHeader(http.StatusForbidden)
+		response := responseFormat.CustomResponse{
+			Status:  http.StatusForbidden,
+			Message: "login failed",
+			Data:    map[string]interface{}{"data": "email not allowed"},
+		}
 		json.NewEncoder(w).Encode(response)
 		return
 	}

--- a/server/http/handlers/setup.go
+++ b/server/http/handlers/setup.go
@@ -84,6 +84,9 @@ type HttpHandler struct {
 	signupAllowlistOnce  sync.Once
 	signupAllowlist      map[string]struct{}
 	signupAllowlistErr   error
+	loginAllowlistOnce   sync.Once
+	loginAllowlist       map[string]struct{}
+	loginAllowlistErr    error
 }
 
 type HandlerOptions struct {


### PR DESCRIPTION
Add support for login email allowlist similar to existing signup allowlist. Introduce new environment variables LOGIN_ALLOWED_EMAILS and LOGIN_ALLOWED_EMAILS_FILE. When signup allowlist is empty, fallback to login allowlist for backward compatibility.