### PR TITLE
fix(data): change API response fields to string types

### DIFF
--- a/db/models/telcom/data.go
+++ b/db/models/telcom/data.go
@@ -19,6 +19,6 @@ type DataResult struct {
 	TransactionID          string    `json:"transaction_id" bson:"transaction_id"`
 	ReferenceNumber        string    `json:"reference_number" bson:"reference_number"`
 	CreatedAt              time.Time `json:"created_at" bson:"created_at"`
-	ApiID                  int       `bson:"apiID"`
+	ApiID                  string    `bson:"apiID"`
 	Profit_Margin          string    `json:"-" bson:"profit_margin"`
 }

--- a/lib/telcom/data/data.go
+++ b/lib/telcom/data/data.go
@@ -150,7 +150,8 @@ func (d *DataConn) buyDontechData(ctx context.Context, data DataInfo) (*telcom.D
 			d.logger.Error("server response error", zap.Any("apiresponse", apiResponse))
 			result.Status = "failed"
 			result.RecipientName = apiResponse.Ident
-			result.ApiID = apiResponse.Id
+			rID := strconv.Itoa(apiResponse.Id)
+			result.ApiID = rID
 			if err := d.saveTransaction(ctx, result); err != nil {
 				d.logger.Error("Database error try again...", zap.Error(err))
 				return nil, errors.New("Database Insert Error...")
@@ -159,7 +160,8 @@ func (d *DataConn) buyDontechData(ctx context.Context, data DataInfo) (*telcom.D
 		}
 
 		result.RecipientName = apiResponse.Ident
-		result.ApiID = apiResponse.Id
+		rID := strconv.Itoa(apiResponse.Id)
+		result.ApiID = rID
 		result.Status = "success"
 		if err := d.saveTransaction(ctx, result); err != nil {
 			d.logger.Error("Database error try again...", zap.Error(err))
@@ -397,6 +399,7 @@ func (d *DataConn) buy247Data(ctx context.Context, data DataInfo) (*telcom.DataR
 
 	status = "success"
 	result.Status = status
+	result.ApiID = apiResponse.RequestID
 
 	if err := d.saveTransaction(ctx, result); err != nil {
 		d.logger.Error("Database error try again...", zap.Error(err))

--- a/lib/telcom/data/model.go
+++ b/lib/telcom/data/model.go
@@ -41,7 +41,7 @@ type api247Response struct {
 	Message   string  `json:"message"`
 	Response  string  `json:"response"`
 	RequestID string  `json:"request-id"`
-	Amount    float64 `json:"amount"`
+	Amount    string  `json:"amount"`
 	DataSize  string  `json:"data_size"`
 	Network   string  `json:"network"`
 	DataType  string  `json:"data_type"`


### PR DESCRIPTION
Update Amount field in api247Response from float64 to string to match API format. Change ApiID field in DataResult from int to string to accommodate both numeric and string identifiers. Convert integer API IDs to strings in buyDontechData and set RequestID as ApiID in buy247Data.