### PR TITLE
feat(identity): add duplicate detection for BVN/NIN verification

### DIFF
--- a/db/datastore.go
+++ b/db/datastore.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"context"
+	"time"
 
 	"github.com/aremxyplug-be/db/models"
 	"github.com/aremxyplug-be/db/models/telcom"
@@ -85,6 +86,10 @@ type UserStore interface {
 	UpdateUserPasswordByID(ctx context.Context, id string, password string) error
 	UpdateBVNField(ctx context.Context, user models.User) error
 	UpdateNINField(ctx context.Context, user models.User) error
+	GetUserByBVNHash(ctx context.Context, hash string) (*models.User, error)
+	GetUserByNINHash(ctx context.Context, hash string) (*models.User, error)
+	ListOtherVerifiedUsersByDOB(ctx context.Context, excludeUserID string, dob time.Time) ([]models.User, error)
+	BackfillIdentityHashes(ctx context.Context) error
 	VerifyUser(ctx context.Context, identifier string) (*models.User, error)
 	UpdatePhone(ctx context.Context, id, phone string) error
 	UpdateEmail(ctx context.Context, id, email string) error

--- a/db/models/user.go
+++ b/db/models/user.go
@@ -15,8 +15,10 @@ type User struct {
 	CreatedAt       time.Time `json:"created_at" bson:"created_at"`
 	UpdatedAt       time.Time `json:"updated_at" bson:"updated_at"`
 	BVN             string    `json:"bvn" bson:"bvn"`
+	BVNHash         string    `json:"-" bson:"bvn_hash,omitempty"`
 	BVNPhone        string    `json:"bvn_phone,omitempty" bson:"bvn_phone,omitempty"`
 	NIN             string    `json:"nin" bson:"nin"`
+	NINHash         string    `json:"-" bson:"nin_hash,omitempty"`
 	DOB             time.Time `json:"birth_date" bson:"birth_date"`
 	IsVerified      bool      `json:"is_verified" bson:"is_verified"`
 	HasPin          bool      `json:"has_Pin" bson:"has_Pin"`

--- a/db/mongo/identity.go
+++ b/db/mongo/identity.go
@@ -1,0 +1,185 @@
+package mongo
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/aremxyplug-be/db/models"
+	"github.com/aremxyplug-be/lib/encryption"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+func (m *mongoStore) initIdentityIndexes(ctx context.Context) error {
+	ctx = m.ensureCtx(ctx)
+
+	indexes := []mongo.IndexModel{
+		{
+			Keys:    bson.D{{Key: "bvn_hash", Value: 1}},
+			Options: options.Index().SetUnique(true).SetSparse(true),
+		},
+		{
+			Keys:    bson.D{{Key: "nin_hash", Value: 1}},
+			Options: options.Index().SetUnique(true).SetSparse(true),
+		},
+	}
+
+	if _, err := m.col(userColl).Indexes().CreateMany(ctx, indexes); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *mongoStore) GetUserByBVNHash(ctx context.Context, hash string) (*models.User, error) {
+	return m.getUserByIdentityHash(ctx, "bvn_hash", hash)
+}
+
+func (m *mongoStore) GetUserByNINHash(ctx context.Context, hash string) (*models.User, error) {
+	return m.getUserByIdentityHash(ctx, "nin_hash", hash)
+}
+
+func (m *mongoStore) getUserByIdentityHash(ctx context.Context, field, hash string) (*models.User, error) {
+	ctx = m.ensureCtx(ctx)
+	if hash == "" {
+		return nil, mongo.ErrNoDocuments
+	}
+
+	user := &models.User{}
+	err := m.col(userColl).FindOne(ctx, bson.M{field: hash}).Decode(user)
+	if err != nil {
+		return nil, err
+	}
+
+	return user, nil
+}
+
+func (m *mongoStore) ListOtherVerifiedUsersByDOB(ctx context.Context, excludeUserID string, dob time.Time) ([]models.User, error) {
+	ctx = m.ensureCtx(ctx)
+
+	filter := bson.M{
+		"birth_date": dob,
+		"$or": []bson.M{
+			{"has_bvn": true},
+			{"has_nin": true},
+		},
+	}
+	if excludeUserID != "" {
+		filter["id"] = bson.M{"$ne": excludeUserID}
+	}
+
+	cur, err := m.col(userColl).Find(ctx, filter)
+	if err != nil {
+		return nil, err
+	}
+	defer cur.Close(ctx)
+
+	users := make([]models.User, 0)
+	for cur.Next(ctx) {
+		var user models.User
+		if err := cur.Decode(&user); err != nil {
+			return nil, err
+		}
+		users = append(users, user)
+	}
+
+	if err := cur.Err(); err != nil {
+		return nil, err
+	}
+
+	return users, nil
+}
+
+func (m *mongoStore) BackfillIdentityHashes(ctx context.Context) error {
+	ctx = m.ensureCtx(ctx)
+
+	if err := m.backfillIdentityHashField(ctx, identityBackfillConfig{
+		label:          "bvn",
+		hasField:       "has_bvn",
+		encryptedField: "bvn",
+		hashField:      "bvn_hash",
+		getEncrypted: func(user models.User) string {
+			return user.BVN
+		},
+		lookupExisting: m.GetUserByBVNHash,
+	}); err != nil {
+		return err
+	}
+
+	if err := m.backfillIdentityHashField(ctx, identityBackfillConfig{
+		label:          "nin",
+		hasField:       "has_nin",
+		encryptedField: "nin",
+		hashField:      "nin_hash",
+		getEncrypted: func(user models.User) string {
+			return user.NIN
+		},
+		lookupExisting: m.GetUserByNINHash,
+	}); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+type identityBackfillConfig struct {
+	label          string
+	hasField       string
+	encryptedField string
+	hashField      string
+	getEncrypted   func(models.User) string
+	lookupExisting func(context.Context, string) (*models.User, error)
+}
+
+func (m *mongoStore) backfillIdentityHashField(ctx context.Context, cfg identityBackfillConfig) error {
+	filter := bson.M{
+		cfg.hasField:       true,
+		cfg.encryptedField: bson.M{"$ne": ""},
+		"$or": []bson.M{
+			{cfg.hashField: bson.M{"$exists": false}},
+			{cfg.hashField: ""},
+		},
+	}
+
+	cur, err := m.col(userColl).Find(ctx, filter)
+	if err != nil {
+		return err
+	}
+	defer cur.Close(ctx)
+
+	for cur.Next(ctx) {
+		var user models.User
+		if err := cur.Decode(&user); err != nil {
+			return err
+		}
+
+		plain, err := encryption.DecryptString(cfg.getEncrypted(user))
+		if err != nil {
+			return fmt.Errorf("failed to decrypt %s for user %s: %w", cfg.label, user.ID, err)
+		}
+		hash := encryption.HashIdentityID(plain)
+
+		existing, err := cfg.lookupExisting(ctx, hash)
+		switch {
+		case err == nil && existing.ID != "" && existing.ID != user.ID:
+			return fmt.Errorf("duplicate %s found for users %s and %s", cfg.label, existing.ID, user.ID)
+		case err != nil && err != mongo.ErrNoDocuments:
+			return err
+		}
+
+		_, err = m.col(userColl).UpdateOne(ctx, bson.M{"id": user.ID}, bson.M{
+			"$set": bson.M{cfg.hashField: hash},
+		})
+		if err != nil {
+			return err
+		}
+	}
+
+	if err := cur.Err(); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/db/mongo/mongo.go
+++ b/db/mongo/mongo.go
@@ -53,6 +53,12 @@ func New(connectURI, databaseName string, logger *zap.Logger) (db.DataStore, *mo
 	if err := store.InitIndexes(); err != nil {
 		return nil, nil, fmt.Errorf("failed to initialize indexes: %w", err)
 	}
+	if err := store.BackfillIdentityHashes(ctx); err != nil {
+		return nil, nil, fmt.Errorf("failed to backfill identity hashes: %w", err)
+	}
+	if err := store.initIdentityIndexes(ctx); err != nil {
+		return nil, nil, fmt.Errorf("failed to initialize identity indexes: %w", err)
+	}
 
 	return store, client, nil
 }
@@ -105,6 +111,17 @@ func (m *mongoStore) InitIndexes() error {
 	}
 	if _, err := db.Collection(userColl).Indexes().CreateOne(ctx, userIndex); err != nil {
 		return fmt.Errorf("failed to create user index: %w", err)
+	}
+
+	identityLookupIndex := mongo.IndexModel{
+		Keys: bson.D{
+			{Key: "birth_date", Value: 1},
+			{Key: "has_bvn", Value: 1},
+			{Key: "has_nin", Value: 1},
+		},
+	}
+	if _, err := db.Collection(userColl).Indexes().CreateOne(ctx, identityLookupIndex); err != nil {
+		return fmt.Errorf("failed to create identity lookup index: %w", err)
 	}
 
 	bankIndex := mongo.IndexModel{
@@ -340,7 +357,7 @@ func (m *mongoStore) UpdateUserPasswordByID(ctx context.Context, id string, pass
 func (m *mongoStore) UpdateBVNField(ctx context.Context, user models.User) error {
 	ctx = m.ensureCtx(ctx)
 	filter := bson.M{"id": user.ID}
-	update := bson.M{"$set": bson.M{"bvn": user.BVN, "bvn_phone": user.BVNPhone, "has_bvn": true}}
+	update := bson.M{"$set": bson.M{"bvn": user.BVN, "bvn_hash": user.BVNHash, "bvn_phone": user.BVNPhone, "has_bvn": true}}
 	_, err := m.col(userColl).
 		UpdateOne(ctx, filter, update)
 	if err != nil {
@@ -352,7 +369,7 @@ func (m *mongoStore) UpdateBVNField(ctx context.Context, user models.User) error
 func (m *mongoStore) UpdateNINField(ctx context.Context, user models.User) error {
 	ctx = m.ensureCtx(ctx)
 	filter := bson.M{"id": user.ID}
-	update := bson.M{"$set": bson.M{"nin": user.NIN, "has_nin": true}}
+	update := bson.M{"$set": bson.M{"nin": user.NIN, "nin_hash": user.NINHash, "has_nin": true}}
 	_, err := m.col(userColl).
 		UpdateOne(ctx, filter, update)
 	if err != nil {
@@ -378,7 +395,7 @@ func (m *mongoStore) UpdateEmail(ctx context.Context, id, email string) error {
 func (m *mongoStore) UpdatePhone(ctx context.Context, id, phone string) error {
 	ctx = m.ensureCtx(ctx)
 	filter := bson.M{"id": id}
-	update := bson.M{"$set": bson.M{"phone_number": phone}}
+	update := bson.M{"$set": bson.M{"phonenumber": phone}}
 	coll := m.col(userColl)
 	_, err := coll.UpdateOne(ctx, filter, update)
 	if err != nil {

--- a/lib/encryption/encryption.go
+++ b/lib/encryption/encryption.go
@@ -5,6 +5,7 @@ import (
 	"crypto/cipher"
 	"crypto/rand"
 	"crypto/sha256"
+	"encoding/hex"
 	"encoding/base64"
 	"errors"
 	"io"
@@ -85,4 +86,15 @@ func MaskID(id string) string {
 		return strings.Repeat("*", n)
 	}
 	return strings.Repeat("*", n-4) + id[n-4:]
+}
+
+// NormalizeIdentityID trims outer whitespace before hashing or encryption.
+func NormalizeIdentityID(id string) string {
+	return strings.TrimSpace(id)
+}
+
+// HashIdentityID returns a deterministic SHA-256 hex digest for exact-match checks.
+func HashIdentityID(id string) string {
+	sum := sha256.Sum256([]byte(NormalizeIdentityID(id)))
+	return hex.EncodeToString(sum[:])
 }

--- a/server/http/handlers/extras_handlers.go
+++ b/server/http/handlers/extras_handlers.go
@@ -547,6 +547,33 @@ func (handler *HttpHandler) VerifyIdentity(w http.ResponseWriter, r *http.Reques
 			return
 		}
 
+		bvnHash := encryption.HashIdentityID(req.BVN)
+		existingUser, err := handler.findExactIdentityConflict(ctx, "bvn", bvnHash, user.ID)
+		if err != nil {
+			handler.logger.Error("Failed to check BVN reuse", zap.Error(err))
+			w.WriteHeader(http.StatusInternalServerError)
+			response := responseFormat.CustomResponse{Status: http.StatusInternalServerError, Message: "error", Data: map[string]interface{}{"data": err.Error()}}
+			json.NewEncoder(w).Encode(response)
+			return
+		}
+		if existingUser != nil {
+			handler.respondDuplicateIdentityConflict(w, user.ID, "bvn", "exact_id_reuse", existingUser)
+			return
+		}
+
+		existingUser, err = handler.findDOBNameConflict(ctx, *user, result.DOB)
+		if err != nil {
+			handler.logger.Error("Failed to check BVN DOB/name overlap", zap.Error(err))
+			w.WriteHeader(http.StatusInternalServerError)
+			response := responseFormat.CustomResponse{Status: http.StatusInternalServerError, Message: "error", Data: map[string]interface{}{"data": err.Error()}}
+			json.NewEncoder(w).Encode(response)
+			return
+		}
+		if existingUser != nil {
+			handler.respondDuplicateIdentityConflict(w, user.ID, "bvn", "dob_name_overlap", existingUser)
+			return
+		}
+
 		encBVN, err := encryption.EncryptString(req.BVN)
 		if err != nil {
 			handler.logger.Error("Failed to encrypt BVN", zap.Error(err))
@@ -557,6 +584,7 @@ func (handler *HttpHandler) VerifyIdentity(w http.ResponseWriter, r *http.Reques
 		}
 
 		user.BVN = encBVN
+		user.BVNHash = bvnHash
 		user.BVNPhone = req.Phone
 		if err := handler.store.UpdateBVNField(ctx, *user); err != nil {
 			handler.logger.Error("Failed to update BVN field", zap.Error(err))
@@ -618,6 +646,33 @@ func (handler *HttpHandler) VerifyIdentity(w http.ResponseWriter, r *http.Reques
 			return
 		}
 
+		ninHash := encryption.HashIdentityID(req.NIN)
+		existingUser, err := handler.findExactIdentityConflict(ctx, "nin", ninHash, user.ID)
+		if err != nil {
+			handler.logger.Error("Failed to check NIN reuse", zap.Error(err))
+			w.WriteHeader(http.StatusInternalServerError)
+			response := responseFormat.CustomResponse{Status: http.StatusInternalServerError, Message: "error", Data: map[string]interface{}{"data": err.Error()}}
+			json.NewEncoder(w).Encode(response)
+			return
+		}
+		if existingUser != nil {
+			handler.respondDuplicateIdentityConflict(w, user.ID, "nin", "exact_id_reuse", existingUser)
+			return
+		}
+
+		existingUser, err = handler.findDOBNameConflict(ctx, *user, result.Birthdate)
+		if err != nil {
+			handler.logger.Error("Failed to check NIN DOB/name overlap", zap.Error(err))
+			w.WriteHeader(http.StatusInternalServerError)
+			response := responseFormat.CustomResponse{Status: http.StatusInternalServerError, Message: "error", Data: map[string]interface{}{"data": err.Error()}}
+			json.NewEncoder(w).Encode(response)
+			return
+		}
+		if existingUser != nil {
+			handler.respondDuplicateIdentityConflict(w, user.ID, "nin", "dob_name_overlap", existingUser)
+			return
+		}
+
 		encNIN, err := encryption.EncryptString(req.NIN)
 		if err != nil {
 			handler.logger.Error("Failed to encrypt NIN", zap.Error(err))
@@ -628,6 +683,7 @@ func (handler *HttpHandler) VerifyIdentity(w http.ResponseWriter, r *http.Reques
 		}
 
 		user.NIN = encNIN
+		user.NINHash = ninHash
 		if err := handler.store.UpdateNINField(ctx, *user); err != nil {
 			handler.logger.Error("Failed to update NIN field", zap.Error(err))
 			w.WriteHeader(http.StatusInternalServerError)

--- a/server/http/handlers/identity_guard.go
+++ b/server/http/handlers/identity_guard.go
@@ -1,0 +1,127 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/aremxyplug-be/db/models"
+	"github.com/aremxyplug-be/lib/responseFormat"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.uber.org/zap"
+)
+
+const duplicateIdentityMessage = "existing account found, contact admin"
+
+func normalizeNameParts(name string) map[string]struct{} {
+	parts := strings.Fields(strings.ToLower(strings.TrimSpace(name)))
+	normalized := make(map[string]struct{}, len(parts))
+	for _, part := range parts {
+		if part == "" {
+			continue
+		}
+		normalized[part] = struct{}{}
+	}
+	return normalized
+}
+
+func sharedNamePartCount(left, right string) int {
+	leftParts := normalizeNameParts(left)
+	rightParts := normalizeNameParts(right)
+
+	count := 0
+	for part := range leftParts {
+		if _, ok := rightParts[part]; ok {
+			count++
+		}
+	}
+
+	return count
+}
+
+func hasDOBNameConflict(currentUser, otherUser models.User) bool {
+	if currentUser.ID == otherUser.ID {
+		return false
+	}
+	if currentUser.DOB.IsZero() || otherUser.DOB.IsZero() {
+		return false
+	}
+	if !currentUser.DOB.Equal(otherUser.DOB) {
+		return false
+	}
+
+	return sharedNamePartCount(currentUser.FullName, otherUser.FullName) >= 2
+}
+
+func (handler *HttpHandler) findExactIdentityConflict(ctx context.Context, identityType, hash, currentUserID string) (*models.User, error) {
+	var (
+		user *models.User
+		err  error
+	)
+
+	switch identityType {
+	case "bvn":
+		user, err = handler.store.GetUserByBVNHash(ctx, hash)
+	case "nin":
+		user, err = handler.store.GetUserByNINHash(ctx, hash)
+	default:
+		return nil, nil
+	}
+
+	switch {
+	case err == mongo.ErrNoDocuments:
+		return nil, nil
+	case err != nil:
+		return nil, err
+	case user != nil && user.ID != "" && user.ID != currentUserID:
+		return user, nil
+	default:
+		return nil, nil
+	}
+}
+
+func (handler *HttpHandler) findDOBNameConflict(ctx context.Context, currentUser models.User, dob string) (*models.User, error) {
+	parsedDOB, err := time.Parse("2006-01-02", dob)
+	if err != nil {
+		return nil, err
+	}
+
+	currentUser.DOB = parsedDOB
+
+	users, err := handler.store.ListOtherVerifiedUsersByDOB(ctx, currentUser.ID, parsedDOB)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, candidate := range users {
+		if hasDOBNameConflict(currentUser, candidate) {
+			candidateCopy := candidate
+			return &candidateCopy, nil
+		}
+	}
+
+	return nil, nil
+}
+
+func (handler *HttpHandler) respondDuplicateIdentityConflict(w http.ResponseWriter, currentUserID, verificationType, conflictType string, matchedUser *models.User) {
+	fields := []zap.Field{
+		zap.String("user_id", currentUserID),
+		zap.String("verification_type", verificationType),
+		zap.String("conflict_type", conflictType),
+	}
+	if matchedUser != nil && matchedUser.ID != "" {
+		fields = append(fields, zap.String("matched_user_id", matchedUser.ID))
+	}
+
+	handler.logger.Warn("duplicate identity verification blocked", fields...)
+
+	w.WriteHeader(http.StatusConflict)
+	response := responseFormat.CustomResponse{
+		Status:  http.StatusConflict,
+		Message: "error",
+		Data:    map[string]interface{}{"data": duplicateIdentityMessage},
+	}
+	json.NewEncoder(w).Encode(response)
+}


### PR DESCRIPTION
- Add hash fields (BVNHash, NINHash) to user model for exact-match lookups
- Implement identity guard with exact hash and DOB/name conflict detection
- Backfill existing identity hashes and add unique sparse indexes
- Return conflict response when duplicate identity is detected