### PR TITLE
feat(auth): require verified users for protected routes

### DIFF
--- a/server/http/handlers/extras_handlers.go
+++ b/server/http/handlers/extras_handlers.go
@@ -176,6 +176,11 @@ func (handler *HttpHandler) Pin(w http.ResponseWriter, r *http.Request) {
 		json.NewEncoder(w).Encode(response)
 		return
 	}
+
+	if !ensureSignupVerified(w, user) {
+		handler.logger.Warn("blocked pin creation for unverified user", zap.String("user_id", user.ID))
+		return
+	}
 	id := user.ID
 	ctx := r.Context()
 

--- a/server/http/handlers/http_handlers.go
+++ b/server/http/handlers/http_handlers.go
@@ -416,6 +416,11 @@ func (handler *HttpHandler) Login(w http.ResponseWriter, r *http.Request) {
 		handler.logger.Warn("failed to reset login attempts after successful login", zap.Error(err))
 	}
 
+	if !ensureSignupVerified(w, user) {
+		handler.logger.Warn("blocked login for unverified user", zap.String("user_id", user.ID))
+		return
+	}
+
 	refreshTokenClaims := dto.Claims{
 		PersonId: user.ID,
 	}

--- a/server/http/handlers/verification_guard.go
+++ b/server/http/handlers/verification_guard.go
@@ -1,0 +1,46 @@
+package handlers
+
+import (
+	"net/http"
+
+	"github.com/aremxyplug-be/db/models"
+	"go.uber.org/zap"
+)
+
+const signupVerificationRequiredMessage = "complete signup verification before continuing"
+
+func writeSignupVerificationRequired(w http.ResponseWriter) {
+	writeError(w, http.StatusForbidden, signupVerificationRequiredMessage)
+}
+
+func ensureSignupVerified(w http.ResponseWriter, user *models.User) bool {
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, "unauthorized")
+		return false
+	}
+
+	if user.IsVerified {
+		return true
+	}
+
+	writeSignupVerificationRequired(w)
+	return false
+}
+
+func (handler *HttpHandler) RequireVerifiedUser(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		user, err := handler.GetUserDetails(r)
+		if err != nil {
+			handler.logger.Warn("failed to resolve user details for verification guard", zap.Error(err))
+			writeError(w, http.StatusUnauthorized, "unauthorized")
+			return
+		}
+
+		if !ensureSignupVerified(w, user) {
+			handler.logger.Warn("blocked unverified user from authenticated route", zap.String("user_id", user.ID))
+			return
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}

--- a/server/http/http.go
+++ b/server/http/http.go
@@ -141,7 +141,7 @@ func MountServer(config ServerConfig) *chi.Mux {
 
 		verifyOTPRoutes(router, httpHandler)
 
-		authRouter := router.With(config.Auth.Authorize)
+		authRouter := router.With(config.Auth.Authorize, httpHandler.RequireVerifiedUser)
 
 		authRouter.With(middleware.Timeout(10*time.Second)).Post("/logout", httpHandler.Logout)
 


### PR DESCRIPTION
Add RequireVerifiedUser middleware to authRouter to enforce verification before accessing authenticated endpoints. Block pin creation and login for unverified users by adding verification checks in respective handlers.