### PR TITLE
feat: add card name to TV subscription and finalize referral process

### DIFF
--- a/db/datastore.go
+++ b/db/datastore.go
@@ -30,6 +30,7 @@ type Extras interface {
 	UpdatePin(ctx context.Context, data models.UserPin) error
 	SavePin(ctx context.Context, data models.UserPin) error
 	CreateUserReferral(ctx context.Context, newUserID, referralCode string) error
+	FinalizeSignupReferral(ctx context.Context, newUserID, referralCode string, points int) error
 	GetReferredUsers(ctx context.Context, referrerID string) ([]models.ReferredUserInfo, error)
 	CreatePointDoc(ctx context.Context, userID string) error
 	RedeemPoints(ctx context.Context, userID string, pointsToRedeem int, redeemRate int) (amountRedeemed int, e error)

--- a/db/models/tv_bill.go
+++ b/db/models/tv_bill.go
@@ -10,6 +10,7 @@ type TV_Result struct {
 	IucNumber              string    `json:"iuc_number" bson:"iuc_number"`
 	Phone                  string    `json:"phone_number" bson:"phone_number"`
 	Email                  string    `json:"email" bson:"email"`
+	CardName               string    `json:"card_name,omitempty" bson:"card_name,omitempty"`
 	FullName               string    `json:"full_name" bson:"full_name"`
 	Amount                 int       `json:"amount" bson:"amount"`
 	TransactionProduct     string    `json:"transaction_product" bson:"transaction_product"`

--- a/db/mongo/extras.go
+++ b/db/mongo/extras.go
@@ -86,6 +86,77 @@ func (m *mongoStore) CreateUserReferral(ctx context.Context, newUserID, referral
 	return nil
 }
 
+func (m *mongoStore) FinalizeSignupReferral(ctx context.Context, newUserID, referralCode string, points int) error {
+	ctx = m.ensureCtx(ctx)
+	if referralCode == "" {
+		return nil
+	}
+
+	session, err := m.mongoClient.StartSession()
+	if err != nil {
+		return fmt.Errorf("failed to start session: %v", err)
+	}
+	defer session.EndSession(ctx)
+
+	_, err = session.WithTransaction(ctx, func(sc mongo.SessionContext) (interface{}, error) {
+		var referrer models.User
+		err := m.col("user").FindOne(sc, bson.M{"username": referralCode}).Decode(&referrer)
+		if err != nil {
+			if err == mongo.ErrNoDocuments {
+				m.logger.Warn("referral code not found or invalid", zap.String("code", referralCode))
+				return nil, nil
+			}
+			return nil, fmt.Errorf("failed to resolve referrer: %w", err)
+		}
+
+		referral := models.Referral{
+			UserID:     newUserID,
+			ReferrerID: referrer.ID,
+			ReferredAt: time.Now().UTC(),
+			IsActive:   true,
+		}
+		if _, err := m.col(referralColl).InsertOne(sc, referral); err != nil {
+			return nil, fmt.Errorf("failed to create referral record: %w", err)
+		}
+
+		referrerUpdate := bson.D{
+			{Key: "$inc", Value: bson.D{{Key: "referral_count", Value: 1}}},
+			{Key: "$set", Value: bson.D{{Key: "last_transaction", Value: time.Now().UTC()}}},
+		}
+		updateResult, err := m.col("user").UpdateOne(sc, bson.M{"id": referrer.ID}, referrerUpdate)
+		if err != nil {
+			return nil, fmt.Errorf("failed to update referrer count: %w", err)
+		}
+		if updateResult.MatchedCount == 0 {
+			return nil, ErrMatchedCount
+		}
+
+		pointUpdate := bson.D{
+			{Key: "$inc", Value: bson.D{{Key: "balance", Value: points}}},
+			{Key: "$setOnInsert", Value: bson.D{{Key: "created_at", Value: time.Now().UTC()}}},
+		}
+		opts := options.Update().SetUpsert(true)
+		if _, err := m.col(pointColl).UpdateOne(sc, bson.M{"user_id": referrer.ID}, pointUpdate, opts); err != nil {
+			return nil, fmt.Errorf("failed to update referrer points: %w", err)
+		}
+
+		transaction := models.PointTransaction{
+			UserID:          referrer.ID,
+			TransactionType: "Referral Points",
+			PointEarned:     points,
+			Source:          "referral",
+			CreatedAt:       time.Now().UTC(),
+		}
+		if _, err := m.col(pointTransactionColl).InsertOne(sc, transaction); err != nil {
+			return nil, fmt.Errorf("failed to create referrer point transaction: %w", err)
+		}
+
+		return nil, nil
+	})
+
+	return err
+}
+
 func (m *mongoStore) GetReferredUsers(ctx context.Context, referrerID string) ([]models.ReferredUserInfo, error) {
 	ctx = m.ensureCtx(ctx)
 

--- a/lib/bills/tvsub/response.go
+++ b/lib/bills/tvsub/response.go
@@ -39,6 +39,7 @@ type TvInfo struct {
 	Phone            string `json:"phone"`
 	SubType          string `json:"sub_type"`
 	RequestID        string `json:"request_id"`
+	CardName         string `json:"card_name,omitempty"`
 	Name             string
 	TXN              string
 	Profit_Margin    string

--- a/lib/bills/tvsub/sub.go
+++ b/lib/bills/tvsub/sub.go
@@ -112,6 +112,7 @@ func (t *TvConn) BuySub(ctx context.Context, data TvInfo) (*models.TV_Result, er
 		IucNumber:              data.SmartCard_Number,
 		Phone:                  data.Phone,
 		Email:                  data.Email,
+		CardName:               data.CardName,
 		FullName:               data.Name,
 		TransactionProduct:     transacProd,
 		TransactionDescription: transDesc,

--- a/server/http/handlers/extras_handlers.go
+++ b/server/http/handlers/extras_handlers.go
@@ -227,6 +227,12 @@ func (handler *HttpHandler) Pin(w http.ResponseWriter, r *http.Request) {
 			handler.logger.Warn("failed to add points and update transaction time", zap.Error(err))
 		}
 
+		if user.InvitationCode != "" {
+			if err := handler.store.FinalizeSignupReferral(ctx, user.ID, user.InvitationCode, pointsEarned); err != nil {
+				handler.logger.Warn("failed to finalize deferred signup referral", zap.String("user_id", user.ID), zap.Error(err))
+			}
+		}
+
 		if handler.processor != nil {
 			handler.addevent(ctx, user.ID, "", "", "signup.completed")
 		}

--- a/server/http/handlers/http_handlers.go
+++ b/server/http/handlers/http_handlers.go
@@ -205,13 +205,6 @@ func (handler *HttpHandler) SignUp(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if inviteCode != "" {
-		err := handler.store.CreateUserReferral(ctx, userId, inviteCode)
-		if err != nil {
-			handler.logger.Warn("error updating referral count", zap.Error(err))
-		}
-	}
-
 	userResponse := dto.UserResponse{
 		ID:       newUser.ID,
 		FullName: newUser.FullName,


### PR DESCRIPTION
- Add CardName field to TV subscription data model and propagate through layers
- Move referral processing from signup to pin verification for deferred execution
- Implement transactional referral finalization with points allocation