### PR TITLE
fix(telcom): change amount field type from string to float64

### DIFF
--- a/lib/telcom/data/model.go
+++ b/lib/telcom/data/model.go
@@ -41,7 +41,7 @@ type api247Response struct {
 	Message   string  `json:"message"`
 	Response  string  `json:"response"`
 	RequestID string  `json:"request-id"`
-	Amount    string  `json:"amount"`
+	Amount    float64 `json:"amount"`
 	DataSize  string  `json:"data_size"`
 	Network   string  `json:"network"`
 	DataType  string  `json:"data_type"`


### PR DESCRIPTION
The API response returns numeric values for the amount field, so using float64 provides proper type safety and avoids string parsing.