### PR TITLE
feat(telcom): add data provider failure audit logging

### DIFF
--- a/db/datastore.go
+++ b/db/datastore.go
@@ -101,6 +101,7 @@ type UserStore interface {
 
 type TelcomStore interface {
 	SaveDataTransaction(ctx context.Context, details interface{}) error
+	SaveDataFailureAudit(ctx context.Context, details *telcom.DataFailureAudit) error
 	GetDataTransactionDetails(ctx context.Context, id string) (telcom.DataResult, error)
 	GetAllDataTransactions(ctx context.Context, username string) ([]telcom.DataResult, error)
 	GetSpecTransDetails(ctx context.Context, id string) (telcom.SpectranetResult, error)

--- a/db/models/telcom/data_failure_audit.go
+++ b/db/models/telcom/data_failure_audit.go
@@ -1,0 +1,40 @@
+package telcom
+
+import "time"
+
+type DataFailureAudit struct {
+	UserID          string                 `json:"user_id,omitempty" bson:"user_id,omitempty"`
+	ProviderID      int                    `json:"provider_id" bson:"provider_id"`
+	ProviderName    string                 `json:"provider_name" bson:"provider_name"`
+	FailureType     string                 `json:"failure_type" bson:"failure_type"`
+	Network         string                 `json:"network,omitempty" bson:"network,omitempty"`
+	PlanID          int                    `json:"plan_id,omitempty" bson:"plan_id,omitempty"`
+	PlanName        string                 `json:"plan_name,omitempty" bson:"plan_name,omitempty"`
+	PhoneNumber     string                 `json:"phone_number,omitempty" bson:"phone_number,omitempty"`
+	TransactionID   string                 `json:"transaction_id,omitempty" bson:"transaction_id,omitempty"`
+	OrderID         int                    `json:"order_id,omitempty" bson:"order_id,omitempty"`
+	ReferenceNumber string                 `json:"reference_number,omitempty" bson:"reference_number,omitempty"`
+	Request         AuditRequestSnapshot   `json:"request" bson:"request"`
+	Response        AuditResponseSnapshot  `json:"response" bson:"response"`
+	ErrorMessage    string                 `json:"error_message,omitempty" bson:"error_message,omitempty"`
+	ProviderStatus  string                 `json:"provider_status,omitempty" bson:"provider_status,omitempty"`
+	ProviderMessage string                 `json:"provider_message,omitempty" bson:"provider_message,omitempty"`
+	Metadata        map[string]interface{} `json:"metadata,omitempty" bson:"metadata,omitempty"`
+	CreatedAt       time.Time              `json:"created_at" bson:"created_at"`
+}
+
+type AuditRequestSnapshot struct {
+	Method  string            `json:"method" bson:"method"`
+	URL     string            `json:"url" bson:"url"`
+	Headers map[string]string `json:"headers,omitempty" bson:"headers,omitempty"`
+	Query   map[string]string `json:"query,omitempty" bson:"query,omitempty"`
+	Form    map[string]string `json:"form,omitempty" bson:"form,omitempty"`
+	Body    string            `json:"body,omitempty" bson:"body,omitempty"`
+}
+
+type AuditResponseSnapshot struct {
+	StatusCode int                    `json:"status_code,omitempty" bson:"status_code,omitempty"`
+	Headers    map[string]string      `json:"headers,omitempty" bson:"headers,omitempty"`
+	Body       string                 `json:"body,omitempty" bson:"body,omitempty"`
+	Decoded    map[string]interface{} `json:"decoded,omitempty" bson:"decoded,omitempty"`
+}

--- a/db/mongo/mongo.go
+++ b/db/mongo/mongo.go
@@ -19,13 +19,14 @@ import (
 )
 
 var (
-	dataColl     = "data"
-	eduColl      = "edu"
-	airColl      = "airtime"
-	tvColl       = "tv-sub"
-	electricColl = "elect-sub"
-	userColl     = "user"
-	messagesColl = "messages"
+	dataColl              = "data"
+	dataFailureAuditColl  = "data-failure-audit"
+	eduColl               = "edu"
+	airColl               = "airtime"
+	tvColl                = "tv-sub"
+	electricColl          = "elect-sub"
+	userColl              = "user"
+	messagesColl          = "messages"
 	// verificationsColl = "verifications"
 )
 
@@ -171,6 +172,28 @@ func (m *mongoStore) InitIndexes() error {
 
 	if _, err := db.Collection("tasks").Indexes().CreateMany(ctx, tasksIndex); err != nil {
 		return fmt.Errorf("failed to create tasks index: %w", err)
+	}
+
+	dataFailureAuditIndexes := []mongo.IndexModel{
+		{
+			Keys: bson.D{{Key: "created_at", Value: -1}},
+		},
+		{
+			Keys: bson.D{{Key: "provider_name", Value: 1}, {Key: "created_at", Value: -1}},
+		},
+		{
+			Keys: bson.D{{Key: "failure_type", Value: 1}, {Key: "created_at", Value: -1}},
+		},
+		{
+			Keys: bson.D{{Key: "user_id", Value: 1}, {Key: "created_at", Value: -1}},
+		},
+		{
+			Keys: bson.D{{Key: "transaction_id", Value: 1}},
+		},
+	}
+
+	if _, err := db.Collection(dataFailureAuditColl).Indexes().CreateMany(ctx, dataFailureAuditIndexes); err != nil {
+		return fmt.Errorf("failed to create data failure audit index: %w", err)
 	}
 
 	return nil

--- a/db/mongo/telcom.go
+++ b/db/mongo/telcom.go
@@ -22,6 +22,11 @@ func (m *mongoStore) SaveDataTransaction(ctx context.Context, details interface{
 	return nil
 }
 
+func (m *mongoStore) SaveDataFailureAudit(ctx context.Context, details *telcom.DataFailureAudit) error {
+	ctx = m.ensureCtx(ctx)
+	return m.saveToDB(ctx, dataFailureAuditColl, details)
+}
+
 // getRecordDetails returns a data transaction detail.
 func (m *mongoStore) GetDataTransactionDetails(ctx context.Context, id string) (telcom.DataResult, error) {
 	ctx = m.ensureCtx(ctx)

--- a/lib/telcom/data/data.go
+++ b/lib/telcom/data/data.go
@@ -63,6 +63,177 @@ func (d *DataConn) BuyData(ctx context.Context, data DataInfo) (*telcom.DataResu
 
 }
 
+func (d *DataConn) providerName(providerID int) string {
+	switch providerID {
+	case 1:
+		return "dontech"
+	case 2:
+		return "easyaccess"
+	case 3:
+		return "247api"
+	default:
+		return "unknown"
+	}
+}
+
+func (d *DataConn) networkName(networkID int) (string, error) {
+	switch networkID {
+	case 1:
+		return "MTN", nil
+	case 2:
+		return "GLO", nil
+	case 3:
+		return "9MOBILE", nil
+	case 4:
+		return "AIRTEL", nil
+	default:
+		return "", errors.New("Invalid Network ID")
+	}
+}
+
+func (d *DataConn) newDataResult(data DataInfo, networkStr, referenceNumber string) (*telcom.DataResult, error) {
+	orderID, err := randomgen.GenerateOrderID()
+	if err != nil {
+		d.logger.Error("Could not generate orderID...", zap.Error(err))
+		return nil, d.logAndReturnError("Could not generate orderID", err)
+	}
+
+	transactionDesc := data.Plan_Name + " " + data.PlanSize
+	return &telcom.DataResult{
+		UserID:                 data.UserID,
+		Network:                networkStr,
+		NetworkProduct:         data.Plan_Name,
+		PhoneNumber:            data.Mobile_Num,
+		ReferenceNumber:        referenceNumber,
+		Plan_Amount:            data.Amount,
+		PlanName:               data.Plan_Name,
+		Validity:               data.Validity,
+		CreatedAt:              time.Now().UTC(),
+		OrderID:                orderID,
+		FullName:               data.FullName,
+		TransactionProduct:     "Data Top-up",
+		TransactionDescription: transactionDesc,
+		TransactionID:          randomgen.GenerateTransactionID("dat"),
+		RecipientName:          data.Name,
+		Profit_Margin:          data.Profit_Margin,
+	}, nil
+}
+
+func (d *DataConn) newAuditRequestSnapshot(method, endpoint string, headers map[string]string, body string, query, form map[string]string) telcom.AuditRequestSnapshot {
+	return telcom.AuditRequestSnapshot{
+		Method:  method,
+		URL:     endpoint,
+		Headers: d.sanitizeAuditHeaders(headers),
+		Query:   query,
+		Form:    form,
+		Body:    body,
+	}
+}
+
+func (d *DataConn) sanitizeAuditHeaders(headers map[string]string) map[string]string {
+	if len(headers) == 0 {
+		return nil
+	}
+
+	sanitized := make(map[string]string, len(headers))
+	for key, value := range headers {
+		switch http.CanonicalHeaderKey(key) {
+		case "Authorization", "Authorizationtoken", "Api-Key", "Secret-Key":
+			sanitized[key] = "[REDACTED]"
+		default:
+			sanitized[key] = value
+		}
+	}
+	return sanitized
+}
+
+func (d *DataConn) headerSnapshot(headers http.Header) map[string]string {
+	if len(headers) == 0 {
+		return nil
+	}
+
+	out := make(map[string]string, len(headers))
+	for key, values := range headers {
+		if len(values) == 0 {
+			continue
+		}
+		out[key] = values[0]
+	}
+	return out
+}
+
+func (d *DataConn) valuesSnapshot(values url.Values) map[string]string {
+	if len(values) == 0 {
+		return nil
+	}
+
+	out := make(map[string]string, len(values))
+	for key, entries := range values {
+		if len(entries) == 0 {
+			continue
+		}
+		out[key] = entries[0]
+	}
+	return out
+}
+
+func (d *DataConn) readResponse(resp *http.Response) ([]byte, map[string]string, error) {
+	if resp == nil {
+		return nil, nil, nil
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, d.headerSnapshot(resp.Header), err
+	}
+
+	return body, d.headerSnapshot(resp.Header), nil
+}
+
+func (d *DataConn) decodeRawResponse(raw []byte, target interface{}) (map[string]interface{}, error) {
+	if len(raw) == 0 {
+		return nil, io.EOF
+	}
+
+	if err := json.Unmarshal(raw, target); err != nil {
+		return nil, err
+	}
+
+	decoded := map[string]interface{}{}
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		return nil, nil
+	}
+
+	return decoded, nil
+}
+
+func (d *DataConn) saveFailureAudit(ctx context.Context, data DataInfo, result *telcom.DataResult, request telcom.AuditRequestSnapshot, response telcom.AuditResponseSnapshot, failureType, errorMessage, providerStatus, providerMessage string, metadata map[string]interface{}) {
+	audit := &telcom.DataFailureAudit{
+		UserID:          data.UserID,
+		ProviderID:      data.ProviderID,
+		ProviderName:    d.providerName(data.ProviderID),
+		FailureType:     failureType,
+		Network:         result.Network,
+		PlanID:          data.PlanID,
+		PlanName:        data.Plan_Name,
+		PhoneNumber:     data.Mobile_Num,
+		TransactionID:   result.TransactionID,
+		OrderID:         result.OrderID,
+		ReferenceNumber: result.ReferenceNumber,
+		Request:         request,
+		Response:        response,
+		ErrorMessage:    errorMessage,
+		ProviderStatus:  providerStatus,
+		ProviderMessage: providerMessage,
+		Metadata:        metadata,
+		CreatedAt:       time.Now().UTC(),
+	}
+
+	if err := d.dbConn.SaveDataFailureAudit(ctx, audit); err != nil {
+		d.logger.Warn("failed to save data provider failure audit", zap.Error(err), zap.String("provider", audit.ProviderName), zap.String("failure_type", failureType))
+	}
+}
+
 func (d *DataConn) buyDontechData(ctx context.Context, data DataInfo) (*telcom.DataResult, error) {
 	if ctx == nil {
 		ctx = context.Background()
@@ -79,18 +250,14 @@ func (d *DataConn) buyDontechData(ctx context.Context, data DataInfo) (*telcom.D
 		MobileNumber: data.Mobile_Num,
 		PortedNumber: true,
 	}
-	var networkStr string
-	switch data.Network {
-	case 1:
-		networkStr = "MTN"
-	case 2:
-		networkStr = "GLO"
-	case 3:
-		networkStr = "9MOBILE"
-	case 4:
-		networkStr = "AIRTEL"
-	default:
-		return nil, errors.New("Invalid Network ID")
+	networkStr, err := d.networkName(data.Network)
+	if err != nil {
+		return nil, err
+	}
+
+	result, err := d.newDataResult(data, networkStr, "")
+	if err != nil {
+		return nil, err
 	}
 
 	var buf bytes.Buffer
@@ -98,87 +265,87 @@ func (d *DataConn) buyDontechData(ctx context.Context, data DataInfo) (*telcom.D
 		return nil, d.logAndReturnError("unable to encode data", err)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, "POST", dontechapi+"/data/", &buf)
+	endpoint := dontechapi + "/data/"
+	requestSnapshot := d.newAuditRequestSnapshot(
+		http.MethodPost,
+		endpoint,
+		map[string]string{
+			"Authorization": dontechToken,
+			"Content-Type":  "application/json",
+		},
+		buf.String(),
+		nil,
+		nil,
+	)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewBuffer(buf.Bytes()))
 	if err != nil {
+		d.saveFailureAudit(ctx, data, result, requestSnapshot, telcom.AuditResponseSnapshot{}, "request_build_error", err.Error(), "", "", nil)
 		return nil, err
 	}
-	//req.Header.Set("Access-Control-Allow-Origin", "*")
 	req.Header.Add("Authorization", dontechToken)
 	req.Header.Add("Content-Type", "application/json")
 
 	client := &http.Client{}
 	resp, err := client.Do(req)
 	if err != nil {
+		d.saveFailureAudit(ctx, data, result, requestSnapshot, telcom.AuditResponseSnapshot{}, "transport_error", err.Error(), "", "", nil)
 		return nil, err
 	}
 	defer resp.Body.Close()
 
-	apiResponse := dontechAPIResponse{}
-
-	transactionID := randomgen.GenerateTransactionID("dat")
-	orderID, _ := randomgen.GenerateOrderID()
-	transactionDesc := data.Plan_Name + " " + data.PlanSize
-	result := &telcom.DataResult{
-		UserID:                 data.UserID,
-		Network:                networkStr,
-		NetworkProduct:         data.Plan_Name,
-		PhoneNumber:            data.Mobile_Num,
-		Plan_Amount:            data.Amount,
-		PlanName:               data.Plan_Name,
-		Validity:               data.Validity,
-		CreatedAt:              time.Now().UTC(),
-		OrderID:                orderID,
-		FullName:               data.FullName,
-		TransactionProduct:     "Data Top-up",
-		TransactionDescription: transactionDesc,
-		TransactionID:          transactionID,
-		RecipientName:          data.Name,
-		Profit_Margin:          data.Profit_Margin,
+	rawBody, responseHeaders, err := d.readResponse(resp)
+	responseSnapshot := telcom.AuditResponseSnapshot{
+		StatusCode: resp.StatusCode,
+		Headers:    responseHeaders,
+		Body:       string(rawBody),
+	}
+	if err != nil {
+		d.saveFailureAudit(ctx, data, result, requestSnapshot, responseSnapshot, "decode_error", err.Error(), "", "", nil)
+		return nil, d.logAndReturnError("error while reading response body", err)
 	}
 
-	log.Println(resp.StatusCode)
-	if resp.StatusCode == http.StatusCreated {
+	if resp.StatusCode != http.StatusCreated {
+		d.logger.Error("Api Call Error", zap.String("status", fmt.Sprint(resp.Status)))
+		d.saveFailureAudit(ctx, data, result, requestSnapshot, responseSnapshot, "http_error", resp.Status, "", "", nil)
+		return nil, fmt.Errorf("%v", resp.Status)
+	}
 
-		if err := json.NewDecoder(resp.Body).Decode(&apiResponse); err != nil {
-			if err == io.EOF {
-				return nil, d.logAndReturnError("Empty response body retured from server", err)
-			}
-			return nil, d.logAndReturnError("error while decoding json", err)
+	apiResponse := dontechAPIResponse{}
+	decoded, err := d.decodeRawResponse(rawBody, &apiResponse)
+	if err != nil {
+		responseSnapshot.Decoded = decoded
+		if err == io.EOF {
+			d.saveFailureAudit(ctx, data, result, requestSnapshot, responseSnapshot, "decode_error", "Empty response body retured from server", "", "", nil)
+			return nil, d.logAndReturnError("Empty response body retured from server", err)
 		}
+		d.saveFailureAudit(ctx, data, result, requestSnapshot, responseSnapshot, "decode_error", err.Error(), "", "", nil)
+		return nil, d.logAndReturnError("error while decoding json", err)
+	}
+	responseSnapshot.Decoded = decoded
 
-		if apiResponse.Status != "successful" {
-			d.logger.Error("server response error", zap.Any("apiresponse", apiResponse))
-			result.Status = "failed"
-			result.RecipientName = apiResponse.Ident
-			rID := strconv.Itoa(apiResponse.Id)
-			result.ApiID = rID
-			if err := d.saveTransaction(ctx, result); err != nil {
-				d.logger.Error("Database error try again...", zap.Error(err))
-				return nil, errors.New("Database Insert Error...")
-			}
-			return result, nil
-		}
-
+	if apiResponse.Status != "successful" {
+		d.logger.Error("server response error", zap.Any("apiresponse", apiResponse))
+		result.Status = "failed"
 		result.RecipientName = apiResponse.Ident
-		rID := strconv.Itoa(apiResponse.Id)
-		result.ApiID = rID
-		result.Status = "success"
+		result.ApiID = strconv.Itoa(apiResponse.Id)
+		d.saveFailureAudit(ctx, data, result, requestSnapshot, responseSnapshot, "provider_error", "provider returned unsuccessful status", apiResponse.Status, "", map[string]interface{}{"api_id": apiResponse.Id})
 		if err := d.saveTransaction(ctx, result); err != nil {
 			d.logger.Error("Database error try again...", zap.Error(err))
 			return nil, errors.New("Database Insert Error...")
 		}
-
 		return result, nil
-	} else {
-		d.logger.Error("Api Call Error: %s", zap.String("status", fmt.Sprint((resp.Status))))
-		body, err := json.Marshal(resp.Body)
-		if err != nil {
-			return nil, err
-		}
-		log.Print(string(body))
-		return nil, fmt.Errorf("%v", resp.Status)
 	}
 
+	result.RecipientName = apiResponse.Ident
+	result.ApiID = strconv.Itoa(apiResponse.Id)
+	result.Status = "success"
+	if err := d.saveTransaction(ctx, result); err != nil {
+		d.logger.Error("Database error try again...", zap.Error(err))
+		return nil, errors.New("Database Insert Error...")
+	}
+
+	return result, nil
 }
 
 func (d *DataConn) buyEasyaccessData(ctx context.Context, data DataInfo) (*telcom.DataResult, error) {
@@ -192,22 +359,27 @@ func (d *DataConn) buyEasyaccessData(ctx context.Context, data DataInfo) (*telco
 	requestID := randomgen.GenerateRequestID()
 
 	var network string
-	var networkStr string
 	switch data.Network {
 	case 1:
 		network = "01" //
-		networkStr = "MTN"
 	case 2:
 		network = "02" // GLO
-		networkStr = "GLO"
 	case 3:
 		network = "04" // 9MOBILE
-		networkStr = "9MOBILE"
 	case 4:
 		network = "03" // AIRTEL
-		networkStr = "AIRTEL"
 	default:
 		return nil, errors.New("Invalid Network ID")
+	}
+
+	networkStr, err := d.networkName(data.Network)
+	if err != nil {
+		return nil, err
+	}
+
+	result, err := d.newDataResult(data, networkStr, requestID)
+	if err != nil {
+		return nil, err
 	}
 
 	planID := strconv.Itoa(data.PlanID)
@@ -221,10 +393,23 @@ func (d *DataConn) buyEasyaccessData(ctx context.Context, data DataInfo) (*telco
 
 	body := bytes.NewBufferString(formdata.Encode())
 
-	url := fmt.Sprintf("%s/%s.php", easyaccessapi, "data")
+	endpoint := fmt.Sprintf("%s/%s.php", easyaccessapi, "data")
+	requestSnapshot := d.newAuditRequestSnapshot(
+		http.MethodPost,
+		endpoint,
+		map[string]string{
+			"AuthorizationToken": easyaccessToken,
+			"cache-control":      "no-cache",
+			"Content-Type":       "application/x-www-form-urlencoded",
+		},
+		formdata.Encode(),
+		nil,
+		d.valuesSnapshot(formdata),
+	)
 
-	req, err := http.NewRequestWithContext(ctx, "POST", url, body)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, body)
 	if err != nil {
+		d.saveFailureAudit(ctx, data, result, requestSnapshot, telcom.AuditResponseSnapshot{}, "request_build_error", err.Error(), "", "", nil)
 		return nil, err
 	}
 	req.Header.Set("AuthorizationToken", easyaccessToken)
@@ -234,49 +419,48 @@ func (d *DataConn) buyEasyaccessData(ctx context.Context, data DataInfo) (*telco
 	client := &http.Client{}
 	resp, err := client.Do(req)
 	if err != nil {
+		d.saveFailureAudit(ctx, data, result, requestSnapshot, telcom.AuditResponseSnapshot{}, "transport_error", err.Error(), "", "", nil)
 		return nil, err
 	}
 	defer resp.Body.Close()
 
-	transactionID := randomgen.GenerateTransactionID("dat")
-	id, err := randomgen.GenerateOrderID()
+	rawBody, responseHeaders, err := d.readResponse(resp)
+	responseSnapshot := telcom.AuditResponseSnapshot{
+		StatusCode: resp.StatusCode,
+		Headers:    responseHeaders,
+		Body:       string(rawBody),
+	}
 	if err != nil {
-		d.logger.Error("Could not generate orderID...", zap.Error(err))
-		return nil, d.logAndReturnError("Could not generate orderID", err)
+		d.saveFailureAudit(ctx, data, result, requestSnapshot, responseSnapshot, "decode_error", err.Error(), "", "", nil)
+		return nil, d.logAndReturnError("error while reading response body", err)
 	}
 
-	transactionDesc := data.Plan_Name + " " + data.PlanSize
-
-	result := &telcom.DataResult{
-		UserID:                 data.UserID,
-		Network:                networkStr,
-		NetworkProduct:         data.Plan_Name,
-		PhoneNumber:            data.Mobile_Num,
-		ReferenceNumber:        requestID,
-		Plan_Amount:            data.Amount,
-		PlanName:               data.Plan_Name,
-		Validity:               data.Validity,
-		CreatedAt:              time.Now().UTC(),
-		OrderID:                id,
-		FullName:               data.FullName,
-		TransactionProduct:     "Data Top-up",
-		TransactionDescription: transactionDesc,
-		TransactionID:          transactionID,
-		RecipientName:          data.Name,
-		Profit_Margin:          data.Profit_Margin,
-		// ApiID:                  apiID,
+	if resp.StatusCode != http.StatusOK {
+		d.saveFailureAudit(ctx, data, result, requestSnapshot, responseSnapshot, "http_error", resp.Status, "", "", nil)
+		return nil, fmt.Errorf("%v", resp.Status)
 	}
 
 	apiResponse := easyaccessResponse{}
-	if err := json.NewDecoder(resp.Body).Decode(&apiResponse); err != nil {
+	decoded, err := d.decodeRawResponse(rawBody, &apiResponse)
+	if err != nil {
+		responseSnapshot.Decoded = decoded
 		if err == io.EOF {
+			d.saveFailureAudit(ctx, data, result, requestSnapshot, responseSnapshot, "decode_error", "Empty response body retured from server", "", "", nil)
 			return nil, d.logAndReturnError("Empty response body retured from server", err)
 		}
+		d.saveFailureAudit(ctx, data, result, requestSnapshot, responseSnapshot, "decode_error", err.Error(), "", "", nil)
 		return nil, d.logAndReturnError("error while decoding json", err)
 	}
+	responseSnapshot.Decoded = decoded
+
 	if apiResponse.Status != "Successful" {
 		d.logger.Error("failed to purchase data", zap.Any("apiresponse", apiResponse))
 		result.Status = "failed"
+		d.saveFailureAudit(ctx, data, result, requestSnapshot, responseSnapshot, "provider_error", "provider returned unsuccessful status", apiResponse.Status, apiResponse.Message, map[string]interface{}{
+			"reference":        apiResponse.Reference,
+			"client_reference": apiResponse.Client_reference,
+			"transaction_date": apiResponse.Transaction_date,
+		})
 		if err := d.saveTransaction(ctx, result); err != nil {
 			d.logger.Error("Database error try again...", zap.Error(err))
 			return nil, errors.New("Database Insert Error...")
@@ -303,25 +487,30 @@ func (d *DataConn) buy247Data(ctx context.Context, data DataInfo) (*telcom.DataR
 	// "4": {"id": 4, "network": "9mobile"}
 
 	var network string
-	networkStr := ""
 	switch data.Network {
 	case 1:
 		network = "1" // MTN
-		networkStr = "MTN"
 	case 2:
 		network = "3" // GLO
-		networkStr = "GLO"
 	case 3:
 		network = "4" // 9MOBILE
-		networkStr = "9MOBILE"
 	case 4:
 		network = "2" // AIRTEL
-		networkStr = "AIRTEL"
 	default:
 		return nil, errors.New("Invalid Network ID")
 	}
 
+	networkStr, err := d.networkName(data.Network)
+	if err != nil {
+		return nil, err
+	}
+
 	requestID := randomgen.GenerateRequestID()
+	result, err := d.newDataResult(data, networkStr, requestID)
+	if err != nil {
+		return nil, err
+	}
+
 	planID := strconv.Itoa(data.PlanID)
 
 	query := url.Values{
@@ -332,10 +521,21 @@ func (d *DataConn) buy247Data(ctx context.Context, data DataInfo) (*telcom.DataR
 		"data_plan":  {planID},
 	}
 
-	url := fmt.Sprintf("%s/%s?%s", api247, "data", query.Encode())
+	endpoint := fmt.Sprintf("%s/%s?%s", api247, "data", query.Encode())
+	requestSnapshot := d.newAuditRequestSnapshot(
+		http.MethodPost,
+		endpoint,
+		map[string]string{
+			"Authorization": apiKey247,
+		},
+		"",
+		d.valuesSnapshot(query),
+		nil,
+	)
 
-	req, err := http.NewRequestWithContext(ctx, "POST", url, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, nil)
 	if err != nil {
+		d.saveFailureAudit(ctx, data, result, requestSnapshot, telcom.AuditResponseSnapshot{}, "request_build_error", err.Error(), "", "", nil)
 		return nil, err
 	}
 
@@ -344,52 +544,49 @@ func (d *DataConn) buy247Data(ctx context.Context, data DataInfo) (*telcom.DataR
 	client := &http.Client{}
 	resp, err := client.Do(req)
 	if err != nil {
+		d.saveFailureAudit(ctx, data, result, requestSnapshot, telcom.AuditResponseSnapshot{}, "transport_error", err.Error(), "", "", nil)
 		return nil, err
 	}
 	defer resp.Body.Close()
 
-	transactionID := randomgen.GenerateTransactionID("dat")
-	id, err := randomgen.GenerateOrderID()
+	rawBody, responseHeaders, err := d.readResponse(resp)
+	responseSnapshot := telcom.AuditResponseSnapshot{
+		StatusCode: resp.StatusCode,
+		Headers:    responseHeaders,
+		Body:       string(rawBody),
+	}
 	if err != nil {
-		d.logger.Error("Could not generate orderID...", zap.Error(err))
-		return nil, d.logAndReturnError("Could not generate orderID", err)
+		d.saveFailureAudit(ctx, data, result, requestSnapshot, responseSnapshot, "decode_error", err.Error(), "", "", nil)
+		return nil, d.logAndReturnError("error while reading response body", err)
 	}
 
-	transactionDesc := data.Plan_Name + " " + data.PlanSize
-
-	status := ""
-
-	result := &telcom.DataResult{
-		UserID:                 data.UserID,
-		Network:                networkStr,
-		NetworkProduct:         data.Plan_Name,
-		PhoneNumber:            data.Mobile_Num,
-		ReferenceNumber:        requestID,
-		Plan_Amount:            data.Amount,
-		PlanName:               data.Plan_Name,
-		Validity:               data.Validity,
-		CreatedAt:              time.Now().UTC(),
-		OrderID:                id,
-		FullName:               data.FullName,
-		TransactionProduct:     "Data Top-up",
-		TransactionDescription: transactionDesc,
-		TransactionID:          transactionID,
-		RecipientName:          data.Name,
-		Profit_Margin:          data.Profit_Margin,
-		// ApiID:                  apiID,
+	if resp.StatusCode != http.StatusOK {
+		d.saveFailureAudit(ctx, data, result, requestSnapshot, responseSnapshot, "http_error", resp.Status, "", "", nil)
+		return nil, fmt.Errorf("%v", resp.Status)
 	}
 
 	apiResponse := api247Response{}
-	if err := json.NewDecoder(resp.Body).Decode(&apiResponse); err != nil {
+	decoded, err := d.decodeRawResponse(rawBody, &apiResponse)
+	if err != nil {
+		responseSnapshot.Decoded = decoded
 		if err == io.EOF {
+			d.saveFailureAudit(ctx, data, result, requestSnapshot, responseSnapshot, "decode_error", "Empty response body retured from server", "", "", nil)
 			return nil, d.logAndReturnError("Empty response body retured from server", err)
 		}
+		d.saveFailureAudit(ctx, data, result, requestSnapshot, responseSnapshot, "decode_error", err.Error(), "", "", nil)
 		return nil, d.logAndReturnError("error while decoding json", err)
 	}
+	responseSnapshot.Decoded = decoded
+
 	if apiResponse.Status != "successful" {
 		d.logger.Error("failed to purchase data", zap.Any("apiresponse", apiResponse))
-		status = "failed"
-		result.Status = status
+		result.Status = "failed"
+		d.saveFailureAudit(ctx, data, result, requestSnapshot, responseSnapshot, "provider_error", "provider returned unsuccessful status", apiResponse.Status, apiResponse.Message, map[string]interface{}{
+			"response":   apiResponse.Response,
+			"data_size":  apiResponse.DataSize,
+			"data_type":  apiResponse.DataType,
+			"request_id": apiResponse.RequestID,
+		})
 		if err := d.saveTransaction(ctx, result); err != nil {
 			d.logger.Error("Database error try again...", zap.Error(err))
 			return nil, errors.New("Database Insert Error...")
@@ -397,8 +594,7 @@ func (d *DataConn) buy247Data(ctx context.Context, data DataInfo) (*telcom.DataR
 		return result, nil
 	}
 
-	status = "success"
-	result.Status = status
+	result.Status = "success"
 	result.ApiID = apiResponse.RequestID
 
 	if err := d.saveTransaction(ctx, result); err != nil {


### PR DESCRIPTION
Introduce structured audit logging for data purchase failures across all providers (Dontech, Easyaccess, 247api). Add new DataFailureAudit model with request/response snapshots, database storage, and indexed MongoDB collection. Refactor data purchase methods to capture and persist detailed failure context including sanitized headers, error types, and provider responses for improved debugging and monitoring.