### PR TITLE
feat(telcom): add ID and ProviderID to airtime product model

### DIFF
--- a/db/models/telcom_product.go
+++ b/db/models/telcom_product.go
@@ -27,7 +27,9 @@ type PlanUpdate struct {
 }
 
 type AirtimeProduct struct {
+	ID                int
 	Network           string
+	ProviderID        int
 	Provider_Discount float64
 	Customer_Discount float64
 	Profit_Margin     float64

--- a/db/sqlstore/airtime.go
+++ b/db/sqlstore/airtime.go
@@ -2,19 +2,101 @@ package sqlstore
 
 import (
 	"context"
+	"database/sql"
+	"errors"
+	"fmt"
 
 	"github.com/aremxyplug-be/db/models"
+	"go.uber.org/zap"
 )
 
 func (s *SqlStore) GetAirtimeProduct(ctx context.Context, network string) (models.AirtimeProduct, error) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	query := `SELECT network, provider_discount_percent, customer_discount_percent, profit_margin FROM airtime WHERE network = $1`
+
+	activeQuery := `
+		SELECT
+			a.id,
+			a.provider_id,
+			a.network,
+			a.provider_discount_percent,
+			a.customer_discount_percent,
+			a.profit_margin
+		FROM airtime a
+		INNER JOIN airtime_provider ap ON a.provider_id = ap.id
+		WHERE
+			UPPER(a.network) = $1 AND
+			a.available = TRUE AND
+			ap.available = TRUE
+		ORDER BY a.id ASC
+		LIMIT 1
+	`
+
 	var ap models.AirtimeProduct
-	err := s.db.QueryRowContext(ctx, query, network).Scan(&ap.Network, &ap.Provider_Discount, &ap.Customer_Discount, &ap.Profit_Margin)
+	err := s.db.QueryRowContext(ctx, activeQuery, network).Scan(
+		&ap.ID,
+		&ap.ProviderID,
+		&ap.Network,
+		&ap.Provider_Discount,
+		&ap.Customer_Discount,
+		&ap.Profit_Margin,
+	)
 	if err != nil {
+		if usesLegacyAirtimeSchema(err) {
+			s.logger.Warn("Falling back to legacy airtime schema", zap.String("network", network), zap.Error(err))
+			return s.getLegacyAirtimeProduct(ctx, network)
+		}
+
+		if err == sql.ErrNoRows {
+			s.logger.Warn("No active airtime product found", zap.String("network", network))
+			return models.AirtimeProduct{}, fmt.Errorf("no active airtime product found for network %s: %w", network, err)
+		}
+
+		s.logger.Error("Failed to retrieve airtime product", zap.String("network", network), zap.Error(err))
 		return models.AirtimeProduct{}, err
 	}
+
 	return ap, nil
+}
+
+func (s *SqlStore) getLegacyAirtimeProduct(ctx context.Context, network string) (models.AirtimeProduct, error) {
+	legacyQuery := `
+		SELECT network, provider_discount_percent, customer_discount_percent, profit_margin
+		FROM airtime
+		WHERE network = $1
+	`
+
+	var ap models.AirtimeProduct
+	err := s.db.QueryRowContext(ctx, legacyQuery, network).Scan(
+		&ap.Network,
+		&ap.Provider_Discount,
+		&ap.Customer_Discount,
+		&ap.Profit_Margin,
+	)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			s.logger.Warn("No legacy airtime product found", zap.String("network", network))
+			return models.AirtimeProduct{}, fmt.Errorf("no airtime product found for network %s: %w", network, err)
+		}
+
+		s.logger.Error("Failed to retrieve airtime product from legacy schema", zap.String("network", network), zap.Error(err))
+		return models.AirtimeProduct{}, err
+	}
+
+	return ap, nil
+}
+
+func usesLegacyAirtimeSchema(err error) bool {
+	var sqlStateErr interface{ SQLState() string }
+	if !errors.As(err, &sqlStateErr) {
+		return false
+	}
+
+	switch sqlStateErr.SQLState() {
+	case "42P01", "42703":
+		return true
+	default:
+		return false
+	}
 }

--- a/server/http/handlers/telcom_handlers.go
+++ b/server/http/handlers/telcom_handlers.go
@@ -1,7 +1,9 @@
 package handlers
 
 import (
+	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -90,6 +92,17 @@ func (handler *HttpHandler) Airtime(w http.ResponseWriter, r *http.Request) {
 		// Get product details from database
 		airtimeProduct, err := handler.productClient.GetAirtimeProduct(ctx, network)
 		if err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				handler.logger.Warn("No active airtime product available", zap.String("network", network))
+				w.WriteHeader(http.StatusNotFound)
+				response := responseFormat.CustomResponse{
+					Status:  http.StatusNotFound,
+					Message: "error",
+					Data:    map[string]interface{}{"data": "No active airtime product available for this network"},
+				}
+				json.NewEncoder(w).Encode(response)
+				return
+			}
 			handler.logger.Error("Failed to get airtime product details", zap.String("network", network), zap.Error(err))
 			w.WriteHeader(http.StatusInternalServerError)
 			response := responseFormat.CustomResponse{
@@ -98,6 +111,7 @@ func (handler *HttpHandler) Airtime(w http.ResponseWriter, r *http.Request) {
 				Data:    map[string]interface{}{"data": "Failed to retrieve airtime product details"},
 			}
 			json.NewEncoder(w).Encode(response)
+			return
 		}
 
 		// Get discount percentages from product
@@ -1185,6 +1199,17 @@ func (handler *HttpHandler) AirtimeDiscount(w http.ResponseWriter, r *http.Reque
 
 	prod, err := handler.productClient.GetAirtimeProduct(ctx, network)
 	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			w.WriteHeader(http.StatusNotFound)
+			handler.logger.Warn("No active airtime product available", zap.String("network", network))
+			response := responseFormat.CustomResponse{
+				Status:  http.StatusNotFound,
+				Message: "error",
+				Data:    map[string]interface{}{"data": "No active airtime product available for this network"},
+			}
+			json.NewEncoder(w).Encode(response)
+			return
+		}
 		w.WriteHeader(http.StatusInternalServerError)
 		handler.logger.Error("Failed to retrieve airtime product", zap.String("network", network), zap.Error(err))
 		response := responseFormat.CustomResponse{
@@ -1199,7 +1224,11 @@ func (handler *HttpHandler) AirtimeDiscount(w http.ResponseWriter, r *http.Reque
 	response := responseFormat.CustomResponse{
 		Status:  http.StatusOK,
 		Message: "success",
-		Data:    map[string]interface{}{"discount_percent": prod.Customer_Discount},
+		Data: map[string]interface{}{
+			"discount_percent": prod.Customer_Discount,
+			"id":               prod.ID,
+			"provider_id":      prod.ProviderID,
+		},
 	}
 	json.NewEncoder(w).Encode(response)
 }


### PR DESCRIPTION
- Extend AirtimeProduct struct with ID and ProviderID fields
- Enhance GetAirtimeProduct query to join with provider table and check availability
- Add fallback to legacy schema when new columns are not available
- Return proper 404 response when no active airtime product is found
- Include ID and ProviderID in AirtimeDiscount API response