### PR TITLE
feat: make reward points and redeem limits configurable via environment variables

### DIFF
--- a/config/secret.go
+++ b/config/secret.go
@@ -24,6 +24,12 @@ type Secrets struct {
 	ServiceID            string `json:"TWILIO_SERVICES_ID"`
 	LoginAllowedEmails   string `json:"LOGIN_ALLOWED_EMAILS"`
 	LoginAllowedFile     string `json:"LOGIN_ALLOWED_EMAILS_FILE"`
+	PurchaseRewardPoints int    `json:"PURCHASE_REWARD_POINTS"`
+	SignupRewardPoints   int    `json:"SIGNUP_REWARD_POINTS"`
+	ReferralUserPoints   int    `json:"REFERRAL_USER_VERIFICATION_REWARD_POINTS"`
+	ReferrerRewardPoints int    `json:"REFERRER_VERIFICATION_REWARD_POINTS"`
+	MinRedeemPoints      int    `json:"MIN_REDEEM_POINTS"`
+	MaxRedeemPoints      int    `json:"MAX_REDEEM_POINTS"`
 }
 
 var ss Secrets
@@ -48,6 +54,12 @@ func init() {
 	ss.AppPort = os.Getenv("PORT")
 	ss.LoginAllowedEmails = os.Getenv("LOGIN_ALLOWED_EMAILS")
 	ss.LoginAllowedFile = os.Getenv("LOGIN_ALLOWED_EMAILS_FILE")
+	ss.PurchaseRewardPoints = getenvIntWithDefault("PURCHASE_REWARD_POINTS", 2)
+	ss.SignupRewardPoints = getenvIntWithDefault("SIGNUP_REWARD_POINTS", 50)
+	ss.ReferralUserPoints = getenvIntWithDefault("REFERRAL_USER_VERIFICATION_REWARD_POINTS", 50)
+	ss.ReferrerRewardPoints = getenvIntWithDefault("REFERRER_VERIFICATION_REWARD_POINTS", 50)
+	ss.MinRedeemPoints = getenvIntWithDefault("MIN_REDEEM_POINTS", 10)
+	ss.MaxRedeemPoints = getenvIntWithDefault("MAX_REDEEM_POINTS", 100)
 
 	if ss.AppPort = os.Getenv("PORT"); ss.AppPort == "" {
 		ss.AppPort = "8080"
@@ -80,4 +92,12 @@ func getenvInt(key string) (int, error) {
 		return 0, err
 	}
 	return v, nil
+}
+
+func getenvIntWithDefault(key string, defaultValue int) int {
+	v, err := getenvInt(key)
+	if err != nil {
+		return defaultValue
+	}
+	return v
 }

--- a/db/datastore.go
+++ b/db/datastore.go
@@ -39,7 +39,7 @@ type Extras interface {
 	CreatePointRedeemDoc(ctx context.Context, redeem models.PointRedeem) error
 	LogPointTransaction(ctx context.Context, transaction models.PointTransaction) error
 	GetPointTransactions(ctx context.Context, userID string, page int) ([]models.PointTransaction, error)
-	UpdatePointAfterVerify(ctx context.Context, userID string) error
+	UpdatePointAfterVerify(ctx context.Context, userID string, userPoints int, referrerPoints int) error
 	GetPointRedeemDetails(ctx context.Context, orderID string) (models.PointRedeem, error)
 	GetTotalPointsRedeemed(ctx context.Context, userID string) (int, error)
 }

--- a/db/mongo/extras.go
+++ b/db/mongo/extras.go
@@ -449,7 +449,7 @@ func (m *mongoStore) UpdatePointAndTransactionTime(ctx context.Context, userID s
 	return nil
 }
 
-func (m *mongoStore) UpdatePointAfterVerify(ctx context.Context, userID string) error {
+func (m *mongoStore) UpdatePointAfterVerify(ctx context.Context, userID string, userPoints int, referrerPoints int) error {
 	ctx = m.ensureCtx(ctx)
 	session, err := m.mongoClient.StartSession()
 	if err != nil {
@@ -472,7 +472,7 @@ func (m *mongoStore) UpdatePointAfterVerify(ctx context.Context, userID string) 
 		userPointUpdate := mongo.NewUpdateOneModel().
 			SetFilter(bson.M{"user_id": userID}).
 			SetUpdate(bson.D{
-				{Key: "$inc", Value: bson.D{{Key: "balance", Value: 100}}},
+				{Key: "$inc", Value: bson.D{{Key: "balance", Value: userPoints}}},
 				{Key: "$setOnInsert", Value: bson.D{{Key: "created_at", Value: now}}},
 			}).
 			SetUpsert(true)
@@ -481,7 +481,7 @@ func (m *mongoStore) UpdatePointAfterVerify(ctx context.Context, userID string) 
 		userTxn := models.PointTransaction{
 			UserID:          userID,
 			TransactionType: "Referral Verification",
-			PointEarned:     100,
+			PointEarned:     userPoints,
 			Source:          "referral",
 			CreatedAt:       now,
 		}
@@ -491,7 +491,7 @@ func (m *mongoStore) UpdatePointAfterVerify(ctx context.Context, userID string) 
 			referrerPointUpdate := mongo.NewUpdateOneModel().
 				SetFilter(bson.M{"user_id": referral.ReferrerID}).
 				SetUpdate(bson.D{
-					{Key: "$inc", Value: bson.D{{Key: "balance", Value: 100}}},
+					{Key: "$inc", Value: bson.D{{Key: "balance", Value: referrerPoints}}},
 					{Key: "$setOnInsert", Value: bson.D{{Key: "created_at", Value: now}}},
 				}).
 				SetUpsert(true)
@@ -500,7 +500,7 @@ func (m *mongoStore) UpdatePointAfterVerify(ctx context.Context, userID string) 
 			referrerTxn := models.PointTransaction{
 				UserID:          referral.ReferrerID,
 				TransactionType: "Referral Verification",
-				PointEarned:     100,
+				PointEarned:     referrerPoints,
 				Source:          "referral",
 				CreatedAt:       now,
 			}

--- a/lib/point-redeem/points.go
+++ b/lib/point-redeem/points.go
@@ -12,25 +12,23 @@ import (
 )
 
 type PointConfig struct {
-	db db.Extras
+	db            db.Extras
+	minRedeem     int
+	maxRedeemCap  int
 }
 
-func NewPointConfig(store db.Extras) *PointConfig {
+func NewPointConfig(store db.Extras, minRedeem int, maxRedeemCap int) *PointConfig {
 	return &PointConfig{
-		db: store,
+		db:           store,
+		minRedeem:    minRedeem,
+		maxRedeemCap: maxRedeemCap,
 	}
 }
 
 func (p *PointConfig) RedeemPoints(ctx context.Context, userID string, points int) (models.PointRedeem, error) {
-
-	const (
-		MaxRedeemCap = 100
-		MinRedeem    = 10
-	)
-
 	// Validate minimum points to redeem
-	if points < MinRedeem {
-		return models.PointRedeem{}, fmt.Errorf("minimum redeem is %d points, you requested %d", MinRedeem, points)
+	if points < p.minRedeem {
+		return models.PointRedeem{}, fmt.Errorf("minimum redeem is %d points, you requested %d", p.minRedeem, points)
 	}
 
 	// Get total points already redeemed by this user
@@ -40,8 +38,8 @@ func (p *PointConfig) RedeemPoints(ctx context.Context, userID string, points in
 	}
 
 	// Check if redemption would exceed the cap
-	if totalRedeemed+points > MaxRedeemCap {
-		remainingCap := MaxRedeemCap - totalRedeemed
+	if totalRedeemed+points > p.maxRedeemCap {
+		remainingCap := p.maxRedeemCap - totalRedeemed
 		return models.PointRedeem{}, fmt.Errorf("redemption cap exceeded: you have already redeemed %d points, can only redeem up to %d more", totalRedeemed, remainingCap)
 	}
 

--- a/main.go
+++ b/main.go
@@ -74,7 +74,7 @@ func main() {
 	electSub := elect.NewElectricConn(store, logger)
 	virtualAcc := bankacc.NewBankConfig(store, logger)
 	bankTransc := transactions.NewTransaction(store)
-	point := pointredeem.NewPointConfig(store)
+	point := pointredeem.NewPointConfig(store, secrets.MinRedeemPoints, secrets.MaxRedeemPoints)
 	pin := auth_pin.NewPinConfig(logger, store)
 	sms := termii.NewSMSConn(store, logger)
 	whatsApp := termii.NewWhatsAppClient(logger)

--- a/server/http/handlers/extras_handlers.go
+++ b/server/http/handlers/extras_handlers.go
@@ -340,7 +340,7 @@ func (handler *HttpHandler) finalizePinCreation(ctx context.Context, w http.Resp
 		return err
 	}
 
-	pointsEarned := 100
+	pointsEarned := handler.secrets.SignupRewardPoints
 	if err := handler.addPoints(ctx, w, user.ID, pointsEarned, "Sign-Up Points", "", "referral"); err != nil {
 		handler.logger.Warn("failed to add points and update transaction time", zap.Error(err))
 	}
@@ -678,7 +678,7 @@ func (handler *HttpHandler) VerifyIdentity(w http.ResponseWriter, r *http.Reques
 			return
 		}
 
-		if err := handler.store.UpdatePointAfterVerify(ctx, user.ID); err != nil {
+		if err := handler.store.UpdatePointAfterVerify(ctx, user.ID, handler.secrets.ReferralUserPoints, handler.secrets.ReferrerRewardPoints); err != nil {
 			handler.logger.Warn("Failed to update points after BVN verification", zap.Error(err))
 		}
 
@@ -776,7 +776,7 @@ func (handler *HttpHandler) VerifyIdentity(w http.ResponseWriter, r *http.Reques
 			return
 		}
 
-		if err := handler.store.UpdatePointAfterVerify(ctx, user.ID); err != nil {
+		if err := handler.store.UpdatePointAfterVerify(ctx, user.ID, handler.secrets.ReferralUserPoints, handler.secrets.ReferrerRewardPoints); err != nil {
 			handler.logger.Warn("Failed to update points after NIN verification", zap.Error(err))
 		}
 

--- a/server/http/handlers/telcom_handlers.go
+++ b/server/http/handlers/telcom_handlers.go
@@ -210,7 +210,7 @@ func (handler *HttpHandler) Airtime(w http.ResponseWriter, r *http.Request) {
 				json.NewEncoder(w).Encode(response)
 				return
 			}
-			pointsEarned := 2
+			pointsEarned := handler.secrets.PurchaseRewardPoints
 			if err := handler.addPoints(ctx, w, id, pointsEarned, res.TransactionProduct, res.TransactionID, "transaction"); err != nil {
 				handler.logger.Warn("failed to add points and update transaction time", zap.Error(err))
 			}
@@ -568,7 +568,7 @@ func (handler *HttpHandler) Data(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 
-			pointsEarned := 2
+			pointsEarned := handler.secrets.PurchaseRewardPoints
 
 			if err := handler.addPoints(ctx, w, id, pointsEarned, res.TransactionProduct, res.TransactionID, "transaction"); err != nil {
 				handler.logger.Warn("failed to add points and update transaction time", zap.Error(err))
@@ -784,7 +784,7 @@ func (handler *HttpHandler) SpectranetData(w http.ResponseWriter, r *http.Reques
 			return
 		}
 
-		pointsEarned := 2
+		pointsEarned := handler.secrets.PurchaseRewardPoints
 
 		if err := handler.addPoints(ctx, w, id, pointsEarned, res.TransactionProduct, res.TransactionID, "transaction"); err != nil {
 			handler.logger.Warn("failed to add points and update transaction time", zap.Error(err))
@@ -962,7 +962,7 @@ func (handler *HttpHandler) SmileData(w http.ResponseWriter, r *http.Request) {
 		// 	return
 		// }
 
-		pointsEarned := 2
+		pointsEarned := handler.secrets.PurchaseRewardPoints
 
 		if err := handler.addPoints(ctx, w, id, pointsEarned, res.TransactionProduct, res.TransactionID, "transaction"); err != nil {
 			handler.logger.Warn("failed to add points and update transaction time", zap.Error(err))

--- a/server/http/handlers/utilies_handlers.go
+++ b/server/http/handlers/utilies_handlers.go
@@ -182,7 +182,7 @@ func (handler *HttpHandler) EduPins(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 
-			pointsEarned := 2
+			pointsEarned := handler.secrets.PurchaseRewardPoints
 
 			if err := handler.addPoints(ctx, w, id, pointsEarned, res.TransactionProduct, res.TransactionID, "transaction"); err != nil {
 				handler.logger.Warn("failed to add points and update transaction time", zap.Error(err))
@@ -469,7 +469,7 @@ func (handler *HttpHandler) TVSubscriptions(w http.ResponseWriter, r *http.Reque
 				return
 			}
 
-			pointsEarned := 2
+			pointsEarned := handler.secrets.PurchaseRewardPoints
 
 			if err := handler.addPoints(ctx, w, id, pointsEarned, res.TransactionProduct, res.TransactionID, "transaction"); err != nil {
 				handler.logger.Warn("failed to add points and update transaction time", zap.Error(err))
@@ -723,7 +723,7 @@ func (handler *HttpHandler) ElectricBill(w http.ResponseWriter, r *http.Request)
 				return
 			}
 
-			pointsEarned := 2
+			pointsEarned := handler.secrets.PurchaseRewardPoints
 
 			if err := handler.addPoints(ctx, w, id, pointsEarned, res.TransactionProduct, res.TransactionID, "transaction"); err != nil {
 				handler.logger.Warn("failed to add points and update transaction time", zap.Error(err))


### PR DESCRIPTION
- Add new environment variables for purchase, signup, referral, and verification reward points
- Add environment variables for minimum redeem points and maximum redeem cap
- Update point redeem logic to use configurable limits instead of hardcoded values
- Modify database layer to accept configurable point values for verification rewards
- Update all transaction handlers to use configurable purchase reward points