### PR TITLE
fix(handlers): add proper redis hold release error handling

### DIFF
--- a/server/http/handlers/bank_handlers.go
+++ b/server/http/handlers/bank_handlers.go
@@ -95,6 +95,13 @@ func (handler *HttpHandler) Transfer(w http.ResponseWriter, r *http.Request) {
 
 		resp, err := handler.bankTrf.TransferToBank(ctx, info)
 		if err != nil {
+			// Release the hold in Redis on error
+			if ok, releaseErr := handler.redisClient.ReleaseHold(ctx, userDetails.ID, txID); releaseErr != nil {
+				handler.logger.Error("Failed to release hold on TransferToBank error", zap.Error(releaseErr))
+			} else if !ok {
+				handler.logger.Warn("Hold not found on TransferToBank error", zap.String("txID", txID))
+			}
+
 			w.WriteHeader(http.StatusInternalServerError)
 			response := responseFormat.CustomResponse{Status: http.StatusInternalServerError, Message: "error", Data: map[string]interface{}{"data": err.Error()}}
 			json.NewEncoder(w).Encode(response)
@@ -374,6 +381,13 @@ func (handler *HttpHandler) TransferToAremxyPlug(w http.ResponseWriter, r *http.
 
 	resp, err := handler.bankTrf.TransferToAremxyPlug(ctx, info)
 	if err != nil {
+		// Release the hold in Redis on error
+		if ok, releaseErr := handler.redisClient.ReleaseHold(ctx, userDetails.ID, txnID); releaseErr != nil {
+			handler.logger.Error("Failed to release hold on TransferToAremxyPlug error", zap.Error(releaseErr))
+		} else if !ok {
+			handler.logger.Warn("Hold not found on TransferToAremxyPlug error", zap.String("txnID", txnID))
+		}
+
 		w.WriteHeader(http.StatusInternalServerError)
 		response := responseFormat.CustomResponse{Status: http.StatusInternalServerError, Message: "error", Data: map[string]interface{}{"data": err.Error()}}
 		json.NewEncoder(w).Encode(response)

--- a/server/http/handlers/telcom_handlers.go
+++ b/server/http/handlers/telcom_handlers.go
@@ -177,8 +177,13 @@ func (handler *HttpHandler) Airtime(w http.ResponseWriter, r *http.Request) {
 
 		res, err := handler.vtuClient.BuyAirtime(ctx, data)
 		if err != nil {
-			// Release hold on error
-			handler.redisClient.ReleaseHold(ctx, id, txnID)
+			// Release the hold in Redis on error
+			if ok, releaseErr := handler.redisClient.ReleaseHold(ctx, id, txnID); releaseErr != nil {
+				handler.logger.Error("Failed to release hold on BuyAirtime error", zap.Error(releaseErr))
+			} else if !ok {
+				handler.logger.Warn("Hold not found on BuyAirtime error", zap.String("txnID", txnID))
+			}
+
 			w.WriteHeader(http.StatusInternalServerError)
 			handler.logger.Error("Failed to purchase airtime", zap.Error(err))
 			response := responseFormat.CustomResponse{
@@ -503,7 +508,7 @@ func (handler *HttpHandler) Data(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		newBal, valid, err := handler.checkPayment(userBalance, decimal.NewFromFloat(plan.Amount))
+		newBal, valid, err := handler.checkPayment(userBalance, decimal.NewFromFloatWithExponent(plan.Amount, -2))
 		if !valid || err != nil {
 			w.WriteHeader(http.StatusBadRequest)
 			handler.logger.Error("Payment validation failed", zap.Error(err))
@@ -533,6 +538,13 @@ func (handler *HttpHandler) Data(w http.ResponseWriter, r *http.Request) {
 
 		res, err := handler.dataClient.BuyData(ctx, data)
 		if err != nil {
+			// Release the hold in Redis on error
+			if ok, releaseErr := handler.redisClient.ReleaseHold(ctx, userDetails.ID, txnID); releaseErr != nil {
+				handler.logger.Error("Failed to release hold on BuyData error", zap.Error(releaseErr))
+			} else if !ok {
+				handler.logger.Warn("Hold not found on BuyData error", zap.String("txnID", txnID))
+			}
+
 			w.WriteHeader(http.StatusInternalServerError)
 			handler.logger.Error("Failed to purchase data", zap.Error(err))
 			response := responseFormat.CustomResponse{

--- a/server/http/handlers/utilies_handlers.go
+++ b/server/http/handlers/utilies_handlers.go
@@ -147,6 +147,13 @@ func (handler *HttpHandler) EduPins(w http.ResponseWriter, r *http.Request) {
 		data.TXN = txnID
 		res, err := handler.eduClient.BuyEduPin(ctx, data)
 		if err != nil {
+			// Release the hold in Redis on error
+			if ok, releaseErr := handler.redisClient.ReleaseHold(ctx, userDetails.ID, txnID); releaseErr != nil {
+				handler.logger.Error("Failed to release hold on BuyEduPin error", zap.Error(releaseErr))
+			} else if !ok {
+				handler.logger.Warn("Hold not found on BuyEduPin error", zap.String("txnID", txnID))
+			}
+
 			w.WriteHeader(http.StatusInternalServerError)
 			handler.logger.Error("Failed to buy EduPin", zap.Error(err))
 			response := responseFormat.CustomResponse{
@@ -687,6 +694,13 @@ func (handler *HttpHandler) ElectricBill(w http.ResponseWriter, r *http.Request)
 		data.UserID = userDetails.ID
 		res, err := handler.electClient.PayBill(ctx, data)
 		if err != nil {
+			// Release the hold in Redis on error
+			if ok, releaseErr := handler.redisClient.ReleaseHold(ctx, userDetails.ID, txnID); releaseErr != nil {
+				handler.logger.Error("Failed to release hold on PayBill error", zap.Error(releaseErr))
+			} else if !ok {
+				handler.logger.Warn("Hold not found on PayBill error", zap.String("txnID", txnID))
+			}
+
 			w.WriteHeader(http.StatusInternalServerError)
 			handler.logger.Error("Failed to buy Electricity subscription", zap.Error(err))
 			response := responseFormat.CustomResponse{


### PR DESCRIPTION
add comprehensive error handling for Redis hold release when service operations fail across multiple endpoints, including logging errors on release failure and warning for missing holds. Also fix decimal currency parsing in the data handler by using decimal.NewFromFloatWithExponent with -2 instead of basic NewFromFloat.